### PR TITLE
Inherited the clear_cache method to a few more derived models and the direct view parallel model.

### DIFF
--- a/src/qinfer/derived_models.py
+++ b/src/qinfer/derived_models.py
@@ -114,6 +114,9 @@ class PoisonedModel(Model):
     
     ## METHODS ##
     
+    def clear_cache(self):
+        self._model.clear_cache()
+
     def are_models_valid(self, modelparams):
         return self._model.are_models_valid(modelparams)
     
@@ -357,6 +360,9 @@ class RandomWalkModel(Model):
     
     ## METHODS ##
     
+    def clear_cache(self):
+        self._model.clear_cache()
+
     def are_models_valid(self, modelparams):
         return self._model.are_models_valid(modelparams)
     

--- a/src/qinfer/parallel.py
+++ b/src/qinfer/parallel.py
@@ -58,6 +58,8 @@ class DirectViewParallelizedModel(Model):
     ## SPECIAL METHODS ##
     
     def __getstate__(self):
+        # Since instances of this class will be pickled as they are passed to
+        # remote engines, we need to be careful not to include _dv
         return {
             '_serial_model': self._serial_model,
             '_dv': None,
@@ -89,6 +91,9 @@ class DirectViewParallelizedModel(Model):
     
     ## METHODS ##
     
+    def clear_cache(self):
+        self._serial_model.clear_cache()
+
     def are_models_valid(self, modelparams):
         return self._serial_model.are_models_valid(modelparams)
     


### PR DESCRIPTION
I couldn't figure out where my memory leak was, and then I realized it was as simple as this.
