### PR TITLE
Travis, Coveralls, CodeClimate, and a broken import

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,21 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+  pep8:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - python
+ratings:
+  paths:
+  - "**.py"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 Backup/*
 UpgradeLog.htm
 
+## Pycharm Stuff ##
+.idea
+
 ## IPython Checkpoints ##
 .ipynb_checkpoints
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+
+virtualenv:
+  system_site_packages: true
+
+notifications:
+  email: false
+
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b -p $HOME/miniconda
+  - export PATH=$HOME/miniconda/bin:$PATH
+  - export PATH=$HOME/miniconda:$PATH
+  - conda update --yes conda
+
+install:
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose dateutil pandas statsmodels scikit-learn
+  - pip install -r requirements.txt
+  - cd ./src/qinfer
+script:
+  - py.test --cov=.
+
+after_success:
+  - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ ipython
 pytest
 pytest-cov
 pytest-xdist
+
+coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ scipy
 scikit-learn
 ipython
 
+pytest
+pytest-cov
+pytest-xdist

--- a/src/qinfer/__init__.py
+++ b/src/qinfer/__init__.py
@@ -32,7 +32,7 @@ __version__ = '1.0b1'
 ## IMPORTS ####################################################################
 # These imports control what is made available by importing qinfer itself.
 
-from _exceptions import *
+from qinfer._exceptions import *
 
 from qinfer.gpu_models import *
 from qinfer.perf_testing import *


### PR DESCRIPTION
Hello.

I'm coming back with a much lighter PR than #29. This also contains work in response to issue #28 

## Things I Did ##
* I set up [Travis](https://travis-ci.org/) on my GitHub repo, and provided a config file with a workaround for numpy and scipy installation
* Since I'm using PyCharm, i added my IDE files to .gitignore
* I fixed an import in ```qinfer.__init__```, where ```_exceptions``` instead of ```qinfer._exceptions``` was being imported. The test library showed that this was throwing an ```ImportError```, and the new import matches the syntax of the others in ```qinfer```. Based on my builds, this didn't break any code.

### New Requirements Added ###
- [pytest](http://pytest.org/latest/), an alternative to Python's [unittest](https://docs.python.org/2/library/unittest.html) library, offers a tighter default regex to recognize tests (i.e., all test modules, classes, and methods MUST start with ```test_````), and a much terser syntax for assertions and test fixtures. It integrates nicely with other clients, but it's not part of the standard library. I'm free to discuss the merits of this
- [pytest-cov](https://pypi.python.org/pypi/pytest-cov) is an extension to pytest that provides code coverage metrics
- [pytest-xdist](https://pypi.python.org/pypi/pytest-xdist) will allow us to eventually write tests that we could farm out to multiple workers and in parallel. Furthermore, it enables loop-on-fail execution, meaning it can continuously run tests in a subprocess similar to that of [karma.js](https://karma-runner.github.io/0.13/index.html). Very handy if we have a lot of unit tests that run quickly.

- [coveralls](https://pypi.python.org/pypi/coveralls) does online reporting of code coverage to [coveralls.io](https://coveralls.io/).

## Services ##
Utilities have been provided for  [Travis](https://travis-ci.org/), [Coveralls](https://coveralls.io/), and [CodeClimate](https://codeclimate.com/github/MichalKononenko/python-qinfer). Linking these services to GitHub is pretty painless for open-source projects, but obviously I can't do it on my end. If these are of interest to Qinfer, I recommend we implement them. All three come with badges.
