### PR TITLE
ImportError raised if ipywidgets is missing during IPythonProgressBar.

### DIFF
--- a/src/qinfer/ipy.py
+++ b/src/qinfer/ipy.py
@@ -55,6 +55,8 @@ class IPythonProgressBar(object):
         classes.
     """
     def __init__(self):
+        if ipw is None:
+            raise ImportError("IPython support requires the ipywidgets package.")
         self.widget = ipw.FloatProgress(
             value=0.0, min=0.0, max=100.0, step=0.5,
             description=""


### PR DESCRIPTION
If ``ipywidgets`` is not installed, the new ``IPythonProgressBar`` class would raise an error due to ``ipw`` being set to ``None``. This PR fixes this behavior to provide a more useful error message, informing the user that ``ipywidgets`` is required for IPython interaction.