### PR TITLE
Changed install to point to pip/Anaconda.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,15 +16,15 @@ Welcome to QInfer
    :alt: Code Climate
 
 **QInfer** is a library using Bayesian sequential Monte Carlo for quantum
-parameter estimation. Works with Python 2.7, 3.3 and 3.4.
+parameter estimation. Works with Python 2.7, 3.3, 3.4 and 3.5.
 
 Installing QInfer
 =================
 
 We recommend using **QInfer** with the
 `Anaconda distribution`_. Download and install
-Anaconda for your platform, either Python 2 or 3. We
-suggest using Python 3, but **QInfer**
+Anaconda for your platform, either Python 2.7 or 3.5. We
+suggest using Python 3.5, but **QInfer**
 works with either. Once Anaconda is installed, simply run ``pip`` to install **QInfer**::
 
     $ pip install git+https://github.com/QInfer/python-qinfer.git

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,9 @@ We recommend using **QInfer** with the
 `Anaconda distribution`_. Download and install
 Anaconda for your platform, either Python 2.7 or 3.5. We
 suggest using Python 3.5, but **QInfer**
-works with either. Once Anaconda is installed, simply run ``pip`` to install **QInfer**::
+works with either. Next, ensure that you have Git installed. On Windows,
+we suggest the `official Git downloads <https://git-scm.com/downloads>`_.
+Once Anaconda and Git are installed, simply run ``pip`` to install **QInfer**::
 
     $ pip install git+https://github.com/QInfer/python-qinfer.git
 

--- a/README.rst
+++ b/README.rst
@@ -18,59 +18,24 @@ Welcome to QInfer
 **QInfer** is a library using Bayesian sequential Monte Carlo for quantum
 parameter estimation. Works with Python 2.7, 3.3 and 3.4.
 
-
-Obtaining QInfer
-================
-
-A stable version of **QInfer** has not yet been released. Until then,
-the latest version may always be obtained by cloning into the GitHub
-repository::
-
-    $ git clone git@github.com:csferrie/python-qinfer.git
-    
-Once obtained in this way, **QInfer** may be updated by pulling from GitHub::
-
-    $ git pull
-
 Installing QInfer
 =================
 
-**QInfer** provides a setup script, ``setup.py``, for installing from source.
-On Unix-like systems, **QInfer** can be made available globally by running::
+We recommend using **QInfer** with the
+`Anaconda distribution`_. Download and install
+Anaconda for your platform, either Python 2 or 3. We
+suggest using Python 3, but **QInfer**
+works with either. Once Anaconda is installed, simply run ``pip`` to install **QInfer**::
 
-    $ cd /path/to/qinfer/
-    $ sudo python setup.py install
+    $ pip install git+https://github.com/QInfer/python-qinfer.git
 
-On Windows, run ``cmd.exe``, then run the setup script::
+Alternatively, **QInfer** can be installed manually by downloading from GitHub,
+then running the provided installer::
 
-    C:\> cd C:\path\to\qinfer\
-    C:\path\to\qinfer\> python setup.py install
-    
-Note that you may be prompted for permission by User Access Control.
-
-Dependencies
-============
-
-**QInfer** depends on only a very few packages:
-
-- Python 2.7 (may work with earlier, but not tested).
-- NumPy and SciPy.
-- [Optional] `SciKit-Learn`_ required for some advanced features.
-- [Optional] `Sphinx`_ required to rebuild documentation.
-
-On Windows, these packages can be provided by `Python(x,y)`_. Linux users may
-obtain the needed dependencies. Under Ubuntu::
-
-    $ sudo apt-get install python2.7 python-numpy python-scipy python-scikits-learn python-sphinx
-    
-On Fedora::
-
-    $ sudo yum install python numpy scipy python-sphinx
-    $ sudo easy_install -U scikit-learn
-
-Alternatively,
-`Enthought Python Distribution`_ has been tested with **QInfer**, and may be
-used on Windows, Mac OS X or Linux.
+    $ git clone git@github.com:QInfer/python-qinfer.git
+    $ cd python-qinfer
+    $ pip install -r requirements.txt
+    $ python setup.py install
 
 More Information
 ================
@@ -91,7 +56,5 @@ On Windows::
 The generated documentation can be viewed by opening
 ``doc/_build/html/index.html``.
 
-.. _Enthought Python Distribution: http://www.enthought.com/products/epd.php
-.. _Python(x,y): http://code.google.com/p/pythonxy/
-.. _SciKit-Learn: http://scikit-learn.org/stable/
+.. _Anaconda distribution: https://www.continuum.io/downloads
 .. _Sphinx: http://sphinx-doc.org/

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -19,64 +19,25 @@ Additionally, **QInfer** is designed for use with cutting-edge tools, such as
 Python and IPython, making it easier to integrate with the rich community of
 Python-based scientific software libraries.
 
-Obtaining QInfer
-----------------
 
-A fully-stable version of **QInfer** has not yet been released. Until then,
-the latest version may always be obtained by cloning into the GitHub
-repository::
+Installing QInfer
+=================
 
-    $ git clone git@github.com:csferrie/python-qinfer.git
-    
-Once obtained in this way, **QInfer** may be updated by pulling from GitHub::
+We recommend using **QInfer** with the
+`Anaconda distribution`_. Download and install
+Anaconda for your platform, either Python 2 or 3. We
+suggest using Python 3, but **QInfer**
+works with either. Once Anaconda is installed, simply run ``pip`` to install **QInfer**::
 
-    $ git pull
+    $ pip install git+https://github.com/QInfer/python-qinfer.git
 
-Installation
-------------
+Alternatively, **QInfer** can be installed manually by downloading from GitHub,
+then running the provided installer::
 
-**QInfer** provides a setup script, ``setup.py``, for installing from source.
-On Unix-like systems, **QInfer** can be made available globally by running::
-
-    $ cd /path/to/qinfer/
-    $ sudo python setup.py install
-
-On Windows, run ``cmd.exe``, then run the setup script::
-
-    C:\> cd C:\path\to\qinfer\
-    C:\path\to\qinfer\> python setup.py install
-    
-Note that you may be prompted for permission by User Access Control.
-
-Dependencies
-------------
-
-**QInfer** depends on only a very few packages:
-
-- Python 2.7 (may work with earlier, but not tested).
-- NumPy and SciPy.
-
-Some features of **QInfer** require additional packages, but the core of
-**QInfer** will work without them:
-
-- `SciKit-Learn`_ required for some advanced features, such as clustering.
-- `Sphinx`_ required to rebuild documentation.
-- `matplotlib`_ required for plotting functionality.
-- `IPython Notebook`_ (version 1.1) is used to provide examples.
-
-On Windows, these packages can be provided by `Python(x,y)`_. Linux users may
-obtain the needed dependencies using package managers. Under Ubuntu::
-
-    $ sudo apt-get install python2.7 python-numpy python-scipy python-scikits-learn python-matplotlib python-sphinx ipython-notebook
-    
-On Fedora::
-
-    $ sudo yum install python numpy scipy python-sphinx python-matplotlib python-ipython-notebook
-    $ sudo easy_install -U scikit-learn
-
-Alternatively,
-`Enthought Canopy`_ has been tested with **QInfer**, and may be
-used on Windows, Mac OS X or Linux.
+    $ git clone git@github.com:QInfer/python-qinfer.git
+    $ cd python-qinfer
+    $ pip install -r requirements.txt
+    $ python setup.py install
 
 Citing QInfer
 -------------
@@ -86,25 +47,25 @@ if you cited our work. We recommend citing **QInfer** by using the BibTeX
 entry::
 
     @Misc{,
-      author = {Christopher Ferrie and Christopher Granade and others},
+      author = {Christopher Granade and Christopher Ferrie and others},
       title =  {{QInfer}: Library for Statistical Inference in Quantum Information},
       year =   {2012--},
-      url =    "https://github.com/csferrie/python-qinfer"
+      url =    "https://github.com/QInfer/python-qinfer"
     }
 
 To indicate which version of **QInfer** you used in your work, it may be helpful
 to cite a given SHA hash as listed on
-`GitHub <https://github.com/csferrie/python-qinfer/commits/master>`_ (the
+`GitHub <https://github.com/QInfer/python-qinfer/commits/master>`_ (the
 hashes of each commit are listed on the right hand side of the page).
 A recommended BibTeX entry for citing a particular version is::
 
     @Misc{,
-      author = {Christopher Ferrie and Christopher Granade and others},
+      author = {Christopher Granade and Christopher Ferrie and others},
       title =  {{QInfer}: Library for Statistical Inference in Quantum Information},
-      year =   {2013},
+      year =   {2012},
       month =  {2},
       day =    {18},
-      url =    "https://github.com/csferrie/python-qinfer/commit/d04bc1d53933f13065917c15ccb0e2f127de3b8a",
+      url =    "https://github.com/QInfer/python-qinfer/commit/d04bc1d53933f13065917c15ccb0e2f127de3b8a",
       note =   {Version \texttt{d04bc1d53933f13065917c15ccb0e2f127de3b8a}.}
     }
     
@@ -129,10 +90,7 @@ Alternatively, IPython provides an online viewer for reading notebook files:
 
 More details can be found in the :ref:`examples` section.
 
-.. _Enthought Canopy: https://www.enthought.com/products/canopy/
-.. _Python(x,y): http://code.google.com/p/pythonxy/
-.. _matplotlib: http://matplotlib.org/
-.. _SciKit-Learn: http://scikit-learn.org/stable/
+.. _Anaconda distribution: https://www.continuum.io/downloads
 .. _Sphinx: http://sphinx-doc.org/
 .. _IPython Notebook: http://ipython.org/ipython-doc/stable/interactive/notebook.html
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -25,8 +25,8 @@ Installing QInfer
 
 We recommend using **QInfer** with the
 `Anaconda distribution`_. Download and install
-Anaconda for your platform, either Python 2 or 3. We
-suggest using Python 3, but **QInfer**
+Anaconda for your platform, either Python 2.7 or 3.5. We
+suggest using Python 3.5, but **QInfer**
 works with either. Once Anaconda is installed, simply run ``pip`` to install **QInfer**::
 
     $ pip install git+https://github.com/QInfer/python-qinfer.git

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -27,7 +27,9 @@ We recommend using **QInfer** with the
 `Anaconda distribution`_. Download and install
 Anaconda for your platform, either Python 2.7 or 3.5. We
 suggest using Python 3.5, but **QInfer**
-works with either. Once Anaconda is installed, simply run ``pip`` to install **QInfer**::
+works with either. Next, ensure that you have Git installed. On Windows,
+we suggest the `official Git downloads <https://git-scm.com/downloads>`_.
+Once Anaconda and Git are installed, simply run ``pip`` to install **QInfer**::
 
     $ pip install git+https://github.com/QInfer/python-qinfer.git
 


### PR DESCRIPTION
This PR changes the install instructions dramatically to recommend Anaconda for Python 3.5. This should be simpler, but currently the Travis build is broken for 3.5 such that we can't actually claim that it's tested. I'll submit another PR to turn on 3.5 testing, then this PR should make more sense.