### PR TITLE
Removed extraneous conda install args, added Py35 to travis build mtx.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 notifications:
   email: false
@@ -17,7 +18,7 @@ before_install:
   - conda update --yes conda
 
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose dateutil pandas statsmodels scikit-learn
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib scikit-learn
   - pip install -r requirements.txt
   - python setup.py install
   - cd src/


### PR DESCRIPTION
This PR adds Python 3.5 to the build matrix by removing install arguments for packages that are not available on the ``conda python=3.5`` repos.