### PR TITLE
Fix for travis → PyPI deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ script:
 after_success:
   - coveralls
 
+before_deploy:
+  # For why this is needed, see:
+  # http://stackoverflow.com/questions/36635650/travisci-deploy-cannot-find-setup-py
+  - cd ~/
+
 deploy:
   provider: pypi
   user: ${PYPI_USERNAME}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [metadata]
 description-file = README.rst
 
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ if os.path.exists(VERSION_TARGET):
 
 write_version()
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 try:
     with open('README.rst', 'r') as readme:


### PR DESCRIPTION
The travis deploy suggested by @scasagrande almost worked, but I made a minor mistake in setting it up. Specifically, I forgot to [add ``cd ~/`` to the ``before_deploy`` stage](http://stackoverflow.com/questions/36635650/travisci-deploy-cannot-find-setup-py). I don't want to push a new tag for ``v1.0b4``, so I'll deploy manually for now and it should be in place for the next version.