### PR TITLE
Insert required numpy version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.9.0
 scipy
 scikit-learn
 ipython


### PR DESCRIPTION
Not sure what ``requirements.txt`` is used for, but unit testing is failing for me because of the ``dtype ``option in ``np.linspace``.