### PR TITLE
Changed required qutip version to >= 3.2

### DIFF
--- a/src/qinfer/tomography/bases.py
+++ b/src/qinfer/tomography/bases.py
@@ -49,7 +49,7 @@ try:
     import qutip as qt
     from distutils.version import LooseVersion
     _qt_version = LooseVersion(qt.version.version)
-    if _qt_version < LooseVersion('3.1'):
+    if _qt_version < LooseVersion('3.2'):
         qt = None
 except ImportError:
     qt = None

--- a/src/qinfer/tomography/distributions.py
+++ b/src/qinfer/tomography/distributions.py
@@ -50,7 +50,7 @@ try:
     import qutip as qt
     from distutils.version import LooseVersion
     _qt_version = LooseVersion(qt.version.version)
-    if _qt_version < LooseVersion('3.1'):
+    if _qt_version < LooseVersion('3.2'):
         qt = None
 except ImportError:
     qt = None

--- a/src/qinfer/tomography/expdesign.py
+++ b/src/qinfer/tomography/expdesign.py
@@ -56,7 +56,7 @@ try:
     import qutip as qt
     from distutils.version import LooseVersion
     _qt_version = LooseVersion(qt.version.version)
-    if _qt_version < LooseVersion('3.1'):
+    if _qt_version < LooseVersion('3.2'):
         qt = None
 except ImportError:
     qt = None

--- a/src/qinfer/tomography/legacy.py
+++ b/src/qinfer/tomography/legacy.py
@@ -48,7 +48,7 @@ try:
     import qutip as qt
     from distutils.version import LooseVersion
     _qt_version = LooseVersion(qt.version.version)
-    if _qt_version < LooseVersion('3.1'):
+    if _qt_version < LooseVersion('3.2'):
         qt = None
 except ImportError:
     qt = None

--- a/src/qinfer/tomography/plotting_tools.py
+++ b/src/qinfer/tomography/plotting_tools.py
@@ -54,7 +54,7 @@ try:
     import qutip as qt
     from distutils.version import LooseVersion
     _qt_version = LooseVersion(qt.version.version)
-    if _qt_version < LooseVersion('3.1'):
+    if _qt_version < LooseVersion('3.2'):
         qt = None
 except ImportError:
     qt = None


### PR DESCRIPTION
This PR introduces @ihincks's commit ccb776dc8a3a1cec0d7f1140de08506a7dfe3c44 into master. As suggested in #71, ``qinfer.tomography`` should check if QuTiP is at least version 3.2, not 3.1 as is currently done, since many of the random sampling features were not present in 3.1.