### PR TITLE
New SMCUpdater.min_n_ess property

### DIFF
--- a/src/qinfer/tests/base_test.py
+++ b/src/qinfer/tests/base_test.py
@@ -32,11 +32,14 @@ from future.utils import with_metaclass
 ## IMPORTS ####################################################################
 
 import sys
+import warnings
 import abc
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import unittest
 from qinfer import Domain, FiniteOutcomeModel
+
+from contextlib import contextmanager
 
 ## FUNCTIONS ##################################################################
 
@@ -72,6 +75,25 @@ def test_model(model, prior, expparams, stream=sys.stderr):
     test = unittest.TestSuite((TestGivenModel, ))
     runner = unittest.TextTestRunner(stream=stream)
     runner.run(test)
+
+@contextmanager
+def assert_warns(category):
+    """
+    Context manager which asserts that its contents raise a particular
+    warning.
+
+    :param type category: Category of the warning that should be raised.
+    """
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        # Catch everything.
+        warnings.simplefilter('always')
+
+        yield
+    
+    assert(any([
+        isinstance(warning, category) for warning in caught_warnings
+    ]), "No warning of category {} raised.".format(category))
 
 ## CLASSES ####################################################################
 

--- a/src/qinfer/tests/base_test.py
+++ b/src/qinfer/tests/base_test.py
@@ -36,7 +36,7 @@ import abc
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import unittest
-from qinfer import Domain
+from qinfer import Domain, FiniteOutcomeModel
 
 ## FUNCTIONS ##################################################################
 
@@ -74,6 +74,41 @@ def test_model(model, prior, expparams, stream=sys.stderr):
     runner.run(test)
 
 ## CLASSES ####################################################################
+
+class MockModel(FiniteOutcomeModel):
+    """
+    Two-outcome model whose likelihood is always 0.5, irrespective of
+    model parameters, outcomes or experiment parameters.
+    """
+
+    def __init__(self):
+        super(MockModel, self).__init__()
+    
+    @property
+    def n_modelparams(self):
+        return 2
+        
+    @staticmethod
+    def are_models_valid(modelparams):
+        return np.ones((modelparams.shape[0], ), dtype=bool)
+        
+    @property
+    def is_n_outcomes_constant(self):
+        return True
+        
+    def n_outcomes(self, expparams):
+        return 2
+
+        
+    @property
+    def expparams_dtype(self):
+        return [('a', float), ('b', int)]
+        
+    
+    def likelihood(self, outcomes, modelparams, expparams):
+        super(MockModel, self).likelihood(outcomes, modelparams, expparams)
+        pr0 = np.ones((modelparams.shape[0], expparams.shape[0])) / 2
+        return FiniteOutcomeModel.pr0_to_likelihood_array(outcomes, pr0)
 
 class DerandomizedTestCase(unittest.TestCase):
 

--- a/src/qinfer/tests/base_test.py
+++ b/src/qinfer/tests/base_test.py
@@ -91,9 +91,9 @@ def assert_warns(category):
 
         yield
     
-    assert(any([
+    assert any([
         isinstance(warning, category) for warning in caught_warnings
-    ]), "No warning of category {} raised.".format(category))
+    ]), "No warning of category {} raised.".format(category)
 
 ## CLASSES ####################################################################
 

--- a/src/qinfer/tests/base_test.py
+++ b/src/qinfer/tests/base_test.py
@@ -92,7 +92,7 @@ def assert_warns(category):
         yield
     
     assert any([
-        isinstance(warning, category) for warning in caught_warnings
+        issubclass(warning.category, category) for warning in caught_warnings
     ]), "No warning of category {} raised.".format(category)
 
 ## CLASSES ####################################################################

--- a/src/qinfer/tests/test_abstract_model.py
+++ b/src/qinfer/tests/test_abstract_model.py
@@ -33,46 +33,10 @@ from __future__ import division # Ensures that a/b is always a float.
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 
-from qinfer.tests.base_test import DerandomizedTestCase
+from qinfer.tests.base_test import DerandomizedTestCase, MockModel
 from qinfer.abstract_model import FiniteOutcomeModel
     
 ## CLASSES ####################################################################
-
-class MockModel(FiniteOutcomeModel):
-    """
-    Two-outcome model whose likelihood is always 0.5, irrespective of
-    model parameters, outcomes or experiment parameters.
-    """
-
-    def __init__(self):
-        super(MockModel, self).__init__()
-    
-    @property
-    def n_modelparams(self):
-        return 2
-        
-    @staticmethod
-    def are_models_valid(modelparams):
-        return np.ones((modelparams.shape[0], ), dtype=bool)
-        
-    @property
-    def is_n_outcomes_constant(self):
-        return True
-        
-    def n_outcomes(self, expparams):
-        return 2
-
-        
-    @property
-    def expparams_dtype(self):
-        return [('a', float), ('b', int)]
-        
-    
-    def likelihood(self, outcomes, modelparams, expparams):
-        super(MockModel, self).likelihood(outcomes, modelparams, expparams)
-        pr0 = np.ones((modelparams.shape[0], expparams.shape[0])) / 2
-        return FiniteOutcomeModel.pr0_to_likelihood_array(outcomes, pr0)
-    
 
 class TestAbstractModel(DerandomizedTestCase):
     

--- a/src/qinfer/tests/test_smc.py
+++ b/src/qinfer/tests/test_smc.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+##
+# test_smc.py: Checks that properties and methods of
+#     SMCUpdater work as intended.
+##
+# © 2014 Chris Ferrie (csferrie@gmail.com) and
+#        Christopher E. Granade (cgranade@gmail.com)
+#     
+# This file is a part of the Qinfer project.
+# Licensed under the AGPL version 3.
+##
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+## FEATURES ###################################################################
+
+from __future__ import absolute_import
+from __future__ import division # Ensures that a/b is always a float.
+
+## IMPORTS ####################################################################
+
+import numpy as np
+from numpy.testing import assert_equal, assert_almost_equal
+
+from qinfer.tests.base_test import DerandomizedTestCase, MockModel
+from qinfer.abstract_model import FiniteOutcomeModel
+from qinfer.distributions import UniformDistribution
+from qinfer.smc import SMCUpdater
+    
+## CLASSES ####################################################################
+
+class DecimationModel(MockModel):
+    r"""
+    Two-outcome model whose likelihood upon a "0" outcome returns 1 for the
+    first :math:`\alpha` of its model parameters and
+    0 for the rest, where :math:`\alpha` is an experiment parameter.
+    As with most other mock models, this is not a valid statistical
+    model, but is 
+    useful in decimating particle clouds in tests,
+    as this reduces the ESS of an SMC updater using this
+    model by a factor of :math:`\alpha` after each "datum."
+    """
+        
+    @property
+    def expparams_dtype(self):
+        return [('alpha', float)]        
+    
+    def likelihood(self, outcomes, modelparams, expparams):
+        super(DecimationModel, self).likelihood(outcomes, modelparams, expparams)
+
+        assert expparams.shape == (1,) # Only defined for single experiments.
+
+        pr0 = np.ones((modelparams.shape[0], expparams.shape[0])) / 2
+        idx_dec_at = np.ceil(expparams['alpha'][0] * modelparams.shape[0])
+        pr0[idx_dec_at:, :] = 0 
+        
+        return FiniteOutcomeModel.pr0_to_likelihood_array(outcomes, pr0)
+
+## TEST CASES ################################################################
+
+def test_min_n_ess():
+    n_updates = 6
+    n_particles = 4 ** n_updates # Pick factor of 4 to avoid discretization errors.
+    model = DecimationModel()
+    updater = SMCUpdater(model, n_particles, UniformDistribution([0, 1]), resample_thresh=0.0)
+
+    outcomes = np.array([0], dtype=int)
+    expparams = np.empty((1,), dtype=model.expparams_dtype)
+
+    for idx_update in range(n_updates):
+        expparams['alpha'][0] = 4 ** -(idx_update + 1)
+        updater.update(outcomes, expparams)
+        assert_equal(updater.min_n_ess, 4 ** (n_updates - idx_update - 1))
+
+    # Force a resample and ensure that the min_n_ess remains the same.
+    updater.resample()
+    assert_equal(updater.min_n_ess, 4 ** (n_updates - idx_update - 1))

--- a/src/qinfer/tests/test_smc.py
+++ b/src/qinfer/tests/test_smc.py
@@ -38,7 +38,7 @@ from qinfer.tests.base_test import DerandomizedTestCase, MockModel, assert_warns
 from qinfer.abstract_model import FiniteOutcomeModel
 from qinfer.distributions import UniformDistribution
 from qinfer.smc import SMCUpdater
-from qinfer.resamplers import ResamplerWarning
+from qinfer._exceptions import ApproximationWarning
     
 ## CLASSES ####################################################################
 
@@ -93,7 +93,7 @@ class TestSMCEffectiveSampleSize(DerandomizedTestCase):
         expparams = np.ones((1,), dtype=self.model.expparams_dtype)
         expparams['alpha'][0] = 2 / 1000 # Force the particle number to be 2.
 
-        with assert_warns(ResamplerWarning):
+        with assert_warns(ApproximationWarning):
             updater.update(outcomes, expparams) 
 
     def test_resample_thresh(self):

--- a/src/qinfer/tests/test_test.py
+++ b/src/qinfer/tests/test_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+##
+# test_smc.py: Checks that utilities for unit testing
+#     actually run the tests we expect.
+##
+# © 2014 Chris Ferrie (csferrie@gmail.com) and
+#        Christopher E. Granade (cgranade@gmail.com)
+#     
+# This file is a part of the Qinfer project.
+# Licensed under the AGPL version 3.
+##
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+## FEATURES ###################################################################
+
+from __future__ import absolute_import
+from __future__ import division # Ensures that a/b is always a float.
+
+## IMPORTS ####################################################################
+
+import warnings
+import unittest
+
+import numpy as np
+from numpy.testing import assert_equal, assert_almost_equal
+
+from qinfer.tests.base_test import DerandomizedTestCase, MockModel, assert_warns
+
+## TESTS #####################################################################
+
+class TestTest(DerandomizedTestCase):
+
+    def test_assert_warns_ok(self):
+        with assert_warns(RuntimeWarning):
+            warnings.warn(RuntimeWarning("Test"))
+
+    @unittest.expectedFailure
+    def test_assert_warns_nowarn(self):
+        with assert_warns(RuntimeWarning):
+            pass


### PR DESCRIPTION
This PR adds a new property, ``SMCUpdater.min_n_ess``, to track the smallest effective sample size observed in the process of updating a distribution. Please see #88 for discussions.