### PR TITLE
Bugfix for rebit regionest plotting w/ fancy indexing.

### DIFF
--- a/src/qinfer/smc.py
+++ b/src/qinfer/smc.py
@@ -869,6 +869,7 @@ class SMCUpdater(Distribution):
 
         # which slice of modelparams to take
         s_ = np.s_[modelparam_slice] if modelparam_slice is not None else np.s_[:]
+        mps = self.particle_locations[:, s_]
         
         # Start by sorting the particles by weight.
         # We do so by obtaining an array of indices `id_sort` such that
@@ -891,11 +892,11 @@ class SMCUpdater(Distribution):
         # credible particles.
         if return_outside:
             return (
-                self.particle_locations[id_sort, s_][id_cred], 
-                self.particle_locations[id_sort, s_][np.logical_not(id_cred)] 
+                mps[id_sort][id_cred], 
+                mps[id_sort][np.logical_not(id_cred)] 
             )
         else:
-            return self.particle_locations[id_sort, s_][id_cred]
+            return mps[id_sort][id_cred]
     
     def region_est_hull(self, level=0.95, modelparam_slice=None):
         """

--- a/src/qinfer/tomography/plotting_tools.py
+++ b/src/qinfer/tomography/plotting_tools.py
@@ -265,8 +265,8 @@ def plot_rebit_posterior(updater, prior=None, true_state=None, n_std=3, rebit_ax
     elif region_est_method == 'hull':
         # Find the convex hull from the updater, projected
         # on the rebit axes.
-        verticies, simplices = updater.region_est_hull(level, modelparam_slice=rebit_axes)
-        polygon = Polygon(verticies * np.sqrt(2),
+        faces, vertices = updater.region_est_hull(level, modelparam_slice=rebit_axes)
+        polygon = Polygon(vertices * np.sqrt(2),
             facecolor=pallette[0], alpha=0.4, zorder=-9,
             label=r'Credible Region ($\alpha = {}$)'.format(level),
             edgecolor='k', lw=2, fill=True


### PR DESCRIPTION
The recent improvements to region estimation plotting with rebits (#84 and #86) turn out to have a bug when used from ``qinfer.tomography.plotting_tools``. This PR fixes the bug.