### PR TITLE
New distribution: ParticleDistribution

### DIFF
--- a/doc/source/apiref/distributions.rst
+++ b/doc/source/apiref/distributions.rst
@@ -4,9 +4,9 @@
     license, visit http://creativecommons.org/licenses/by-nc-sa/3.0/ or send a
     letter to Creative Commons, 444 Castro Street, Suite 900, Mountain View,
     California, 94041, USA.
-    
+
 .. _distributions:
-    
+
 .. currentmodule:: qinfer
 
 Probability Distributions
@@ -42,7 +42,7 @@ Specific Distributions
 .. autoclass:: MultivariateNormalDistribution
     :members:
 
-.. autoclass:: SlantedNormalDistribution 
+.. autoclass:: SlantedNormalDistribution
     :members:
 
 .. autoclass:: LogNormalDistribution
@@ -51,13 +51,13 @@ Specific Distributions
 .. autoclass:: ConstantDistribution
     :members:
 
-.. autoclass:: BetaDistribution 
+.. autoclass:: BetaDistribution
     :members:
 
-.. autoclass:: BetaBinomialDistribution 
+.. autoclass:: BetaBinomialDistribution
     :members:
 
-.. autoclass:: GammaDistribution 
+.. autoclass:: GammaDistribution
     :members:
 
 .. autoclass:: InterpolatedUnivariateDistribution
@@ -65,13 +65,16 @@ Specific Distributions
 
 .. autoclass:: HilbertSchmidtUniform
     :members:
-    
+
 .. autoclass:: HaarUniform
     :members:
-    
+
 .. autoclass:: GinibreUniform
     :members:
-    
+
+.. autoclass:: ParticleDistribution
+    :members:
+
 Combining Distributions
 -----------------------
 

--- a/src/qinfer/distributions.py
+++ b/src/qinfer/distributions.py
@@ -262,10 +262,11 @@ class ParticleDistribution(Distribution):
         if particle_locations is None or particle_weights is None:
             # Initialize with single particle at origin.
             self.particle_locations = np.zeros((1, dim))
-            self.particle_weights = np.zeros((1,))
+            self.particle_weights = np.ones((1,))
         elif dim is None:
             self.particle_locations = particle_locations
-            self.particle_weights = particle_weights / np.sum(particle_weights)
+            self.particle_weights = np.abs(particle_weights)
+            self.particle_weights = self.particle_weights / np.sum(self.particle_weights)
         else:
             raise ValueError('Either the dimension of parameter space, `dim`, or the particles, `particle_locations` and `particle_weights` must be specified.')
 

--- a/src/qinfer/distributions.py
+++ b/src/qinfer/distributions.py
@@ -249,7 +249,7 @@ class MixtureDistribution(Distribution):
 class ParticleDistribution(Distribution):
     r"""
     A distribution consisting of a list of weighted vectors.
-    Note that either `n_mps` or (`particle_locations`,`particle_weights`)
+    Note that either `n_mps` or both (`particle_locations`, `particle_weights`)
     must be specified, or an error will be raised.
 
     :param numpy.ndarray particle_weights: Length ``n_particles`` list

--- a/src/qinfer/metrics.py
+++ b/src/qinfer/metrics.py
@@ -5,7 +5,7 @@
 ##
 # © 2012 Chris Ferrie (csferrie@gmail.com) and
 #        Christopher E. Granade (cgranade@gmail.com)
-#     
+#
 # This file is a part of the Qinfer project.
 # Licensed under the AGPL version 3.
 ##
@@ -63,35 +63,36 @@ def rescaled_distance_mtx(p, q):
     r"""
     Given two particle updaters for the same model, returns a matrix
     :math:`\matr{d}` with elements
-    
+
     .. math::
         \matr{d}_{i,j} = \left\Vert \sqrt{\matr{Q}} \cdot
             (\vec{x}_{p, i} - \vec{x}_{q, j}) \right\Vert_2,
-            
+
     where :math:`\matr{Q}` is the scale matrix of the model,
     :math:`\vec{x}_{p,i}` is the :math:`i`th particle of ``p``, and where
     :math:`\vec{x}_{q,i}` is the :math:`i`th particle of ``q`.
-    
+
     :param qinfer.smc.SMCUpdater p: SMC updater for the distribution
         :math:`p(\vec{x})`.
     :param qinfer.smc.SMCUpdater q: SMC updater for the distribution
         :math:`q(\vec{x})`.
-        
+
     Either or both of ``p`` or ``q`` can simply be the locations array for
     an :ref:`SMCUpdater`.
     """
-    
+
     # TODO: check that models are actually the same!
-    p_locs = p.particle_locations if isinstance(p, qinfer.smc.SMCUpdater) else p
-    q_locs = q.particle_locations if isinstance(q, qinfer.smc.SMCUpdater) else q
-    
+    p_locs = p.particle_locations if isinstance(p, qinfer.ParticleDistribution) else p
+    q_locs = q.particle_locations if isinstance(q, qinfer.ParticleDistribution) else q
+    Q = p.model.Q if isinstance(p, qinfer.smc.SMCUpdater) else 1
+
     # Because the modelparam axis is last in each of the three cases, we're
     # good as far as broadcasting goes.
-    delta = np.sqrt(p.model.Q) * (
+    delta = np.sqrt(Q) * (
         p_locs[:, np.newaxis, :] -
         q_locs[np.newaxis, :, :]
     )
-    
+
     return np.sqrt(np.sum(delta**2, axis=-1))
 
 def weighted_pairwise_distances(X, w, metric='euclidean', w_pow=0.5):
@@ -103,16 +104,16 @@ def weighted_pairwise_distances(X, w, metric='euclidean', w_pow=0.5):
     vectors, and are hence correspondingly less likely to be considered part of
     the same cluster.
     """
-    
+
     if sklearn is None:
         raise ImportError("This function requires scikit-learn.")
-    
+
     base_metric = sklearn.metrics.pairwise.pairwise_distances(X, metric=metric)
     N = w.shape[0]
     w_matrix = outer_product(w) * N**2
-    
+
     return base_metric / (w_matrix ** w_pow)
-    
+
 ## FINAL IMPORTS ##############################################################
 
 import qinfer.smc

--- a/src/qinfer/tests/test_distributions.py
+++ b/src/qinfer/tests/test_distributions.py
@@ -581,7 +581,7 @@ class TestParticleDistribution(DerandomizedTestCase):
         particle_weights = particle_weights
         particle_locations = np.random.rand(n_particles, dim)
 
-        dist1 = ParticleDistribution(dim=dim)
+        dist1 = ParticleDistribution(n_mps=dim)
         dist2 = ParticleDistribution(
             particle_weights=particle_weights,
             particle_locations=particle_locations
@@ -630,6 +630,31 @@ class TestParticleDistribution(DerandomizedTestCase):
         assert_almost_equal(dist1.n_ess, n_particles)
         assert_almost_equal(dist2.n_ess, 1)
         assert(dist3.n_ess < n_particles and dist3.n_ess > 1)
+
+    def test_moments(self):
+        """
+        Distributions: Tests the moment function (est_mean, etc)
+        of ParticleDistribution.
+        """
+
+        dim = 5
+        n_particles = 100000
+        mu = np.random.randn(dim)
+        cov = np.random.randn(dim,dim)
+        cov = np.dot(cov,cov.T)
+        particle_locations = np.random.multivariate_normal(mu, cov, n_particles)
+        particle_weights = np.random.rand(n_particles)
+
+        dist = ParticleDistribution(
+            particle_weights=particle_weights,
+            particle_locations=particle_locations
+        )
+
+        assert_sigfigs_equal(mu, dist.est_mean(), 1)
+        assert_almost_equal(dist.est_meanfn(lambda x: x**2),np.diag(cov) + mu**2, 0)
+        assert(np.linalg.norm(dist.est_covariance_mtx() - cov) < 0.5)
+
+
 
 
 class TestInterpolatedUnivariateDistribution(DerandomizedTestCase):

--- a/src/qinfer/tests/test_distributions.py
+++ b/src/qinfer/tests/test_distributions.py
@@ -576,8 +576,9 @@ class TestParticleDistribution(DerandomizedTestCase):
         """
         dim = 5
         n_particles = 100
-        particle_weights = np.random.rand(dim)
-        particle_weights = particle_weights / np.sum(particle_weights)
+        # note that these weights are not all positive!
+        particle_weights = np.random.randn(dim)
+        particle_weights = particle_weights
         particle_locations = np.random.rand(n_particles, dim)
 
         dist1 = ParticleDistribution(dim=dim)
@@ -589,10 +590,47 @@ class TestParticleDistribution(DerandomizedTestCase):
         assert(dist1.n_particles == 1)
         assert(dist1.n_rvs == dim)
         assert_almost_equal(dist1.sample(3), np.zeros((3, dim)))
+        assert_almost_equal(np.sum(dist1.particle_weights), 1)
 
         assert(dist2.n_particles == n_particles)
         assert(dist2.n_rvs == dim)
-        assert(dist1.sample(3).shape == (3,dim))
+        assert(dist2.sample(3).shape == (3,dim))
+        # the following demands that ParticleDistribution
+        # retcifies and normalizes whichever weights it is given
+        assert_almost_equal(np.sum(dist2.particle_weights), 1)
+
+    def test_ness(self):
+        """
+        Distributions: Tests the n_ess property of the
+        ParticleDistribution.
+        """
+
+        dim = 5
+        n_particles = 100
+        particle_weights1 = np.ones(n_particles) / n_particles
+        particle_weights2 = np.zeros(n_particles)
+        particle_weights2[0] = 1
+        particle_weights3 = np.random.rand(dim)
+        particle_weights3 = particle_weights3 / np.sum(particle_weights3)
+        particle_locations = np.random.rand(n_particles, dim)
+
+        dist1 = ParticleDistribution(
+            particle_weights=particle_weights1,
+            particle_locations=particle_locations
+        )
+        dist2 = ParticleDistribution(
+            particle_weights=particle_weights2,
+            particle_locations=particle_locations
+        )
+        dist3 = ParticleDistribution(
+            particle_weights=particle_weights3,
+            particle_locations=particle_locations
+        )
+
+        assert_almost_equal(dist1.n_ess, n_particles)
+        assert_almost_equal(dist2.n_ess, 1)
+        assert(dist3.n_ess < n_particles and dist3.n_ess > 1)
+
 
 class TestInterpolatedUnivariateDistribution(DerandomizedTestCase):
     """

--- a/src/qinfer/tests/test_distributions.py
+++ b/src/qinfer/tests/test_distributions.py
@@ -639,6 +639,7 @@ class TestParticleDistribution(DerandomizedTestCase):
 
         dim = 5
         n_particles = 100000
+        # draw particles from a randomly chosen mutivariate normal
         mu = np.random.randn(dim)
         cov = np.random.randn(dim,dim)
         cov = np.dot(cov,cov.T)
@@ -654,7 +655,34 @@ class TestParticleDistribution(DerandomizedTestCase):
         assert_almost_equal(dist.est_meanfn(lambda x: x**2),np.diag(cov) + mu**2, 0)
         assert(np.linalg.norm(dist.est_covariance_mtx() - cov) < 0.5)
 
+    def test_entropy(self):
+        """
+        Distributions: Tests the entropy and related functions of
+        ParticleDistributions.
+        """
 
+        dim = 3
+        n_particles = 100
+        # draw particles from a randomly chosen mutivariate normal
+        mu = np.random.randn(dim)
+        cov = np.random.randn(dim,dim)
+        cov = np.dot(cov,cov.T)
+        particle_locations = np.random.multivariate_normal(mu, cov, n_particles)
+        particle_weights1 = np.ones(n_particles)
+        particle_weights2 = np.random.rand(n_particles)
+
+        dist1 = ParticleDistribution(
+            particle_weights=particle_weights1,
+            particle_locations=particle_locations
+        )
+        dist2 = ParticleDistribution(
+            particle_weights=particle_weights2,
+            particle_locations=particle_locations
+        )
+
+        assert_almost_equal(dist1.est_entropy(), np.log(n_particles))
+        #TODO: test that est_kl_divergence does more than not fail
+        dist1.est_kl_divergence(dist2)
 
 
 class TestInterpolatedUnivariateDistribution(DerandomizedTestCase):

--- a/src/qinfer/tests/test_distributions.py
+++ b/src/qinfer/tests/test_distributions.py
@@ -67,7 +67,7 @@ class TestNormalDistributions(DerandomizedTestCase):
 
     def test_multivar_normal_moments(self):
         """
-        Distributions: Checks that the multivariate 
+        Distributions: Checks that the multivariate
         normal distribtion has the right moments.
         """
         MU = np.array([0,1])
@@ -78,7 +78,7 @@ class TestNormalDistributions(DerandomizedTestCase):
 
         assert_almost_equal(COV, np.cov(samples[:,0],samples[:,1]), 1)
         assert_almost_equal(MU, np.mean(samples, axis=0), 2)
-    
+
     def test_multivar_normal_n_rvs(self):
         """
         Distributions: Tests for expected number of RVS.
@@ -108,8 +108,8 @@ class TestSlantedNormalDistribution(DerandomizedTestCase):
         samples = dist.sample(150000)
 
         assert_sigfigs_equal(
-            np.mean(np.array(ranges), axis=1), 
-            np.mean(samples, axis=0), 
+            np.mean(np.array(ranges), axis=1),
+            np.mean(samples, axis=0),
         1)
         assert_sigfigs_equal(1/12+4, samples[:,0].var(), 1)
         assert_sigfigs_equal(4/12+4, samples[:,1].var(), 1)
@@ -133,12 +133,12 @@ class TestLogNormalDistribution(DerandomizedTestCase):
         samples = dist.sample(150000)
 
         assert_sigfigs_equal(
-            scipy.stats.lognorm.mean(1,3,2), 
-            samples.mean(), 
+            scipy.stats.lognorm.mean(1,3,2),
+            samples.mean(),
             1)
         assert_sigfigs_equal(
-            np.round(scipy.stats.lognorm.var(1,3,2)), 
-            np.round(samples.var()), 
+            np.round(scipy.stats.lognorm.var(1,3,2)),
+            np.round(samples.var()),
             1)
 
     def test_lognormal_n_rvs(self):
@@ -218,7 +218,7 @@ class TestUniformDistribution(DerandomizedTestCase):
         dist = DiscreteUniformDistribution(5)
         assert(dist.n_rvs == 1)
 
-        
+
 
 class TestMVUniformDistribution(DerandomizedTestCase):
     """
@@ -367,7 +367,7 @@ class TestGammaDistribution(DerandomizedTestCase):
         assert samples.shape == (100000,1)
         assert_almost_equal(samples.mean(), mean, 2)
         assert_almost_equal(samples.var(), var, 2)
-    
+
     def test_gamma_n_rvs(self):
         """
         Distributions: Tests for expected number of RVS.
@@ -417,7 +417,7 @@ class TestSingleSampleMixin(DerandomizedTestCase):
 
     def test_single_sample_mixin(self):
         """
-        Distributions: Tests that subclassing from 
+        Distributions: Tests that subclassing from
         SingleSampleMixin works.
         """
 
@@ -486,7 +486,7 @@ class TestMixtureDistribution(DerandomizedTestCase):
     def test_mixture_moments(self):
         """
         Distributions: Checks that MixtureDistributions
-        has the correct mean value for the normal 
+        has the correct mean value for the normal
         distrubution under both input formats.
         """
         weights = np.array([0.25, 0.25, 0.5])
@@ -500,15 +500,15 @@ class TestMixtureDistribution(DerandomizedTestCase):
 
         # Test both input formats
         mix1 = MixtureDistribution(weights, dist_list)
-        mix2 = MixtureDistribution(weights, NormalDistribution, 
+        mix2 = MixtureDistribution(weights, NormalDistribution,
             dist_args=np.vstack([means,vars]).T)
         # Also test with kwargs
-        mix3 = MixtureDistribution(weights, NormalDistribution, 
+        mix3 = MixtureDistribution(weights, NormalDistribution,
             dist_args=np.vstack([means,vars]).T,
             dist_kw_args={'trunc': np.vstack([means-vars/5,means+vars/5]).T})
         # Also test without the shuffle
         mix4 = MixtureDistribution(weights, dist_list, shuffle=False)
-        
+
         s1 = mix1.sample(150000)
         s2 = mix2.sample(150000)
         s3 = mix3.sample(150000)
@@ -562,6 +562,38 @@ class TestMixtureDistribution(DerandomizedTestCase):
         dist = MixtureDistribution(weights, dist_list)
         assert(dist.n_rvs == 2)
 
+class TestParticleDistribution(DerandomizedTestCase):
+    """
+    Tests ``ParticleDistribution``
+    """
+
+    ## TEST METHODS ##
+
+    def test_init(self):
+        """
+        Distributions: Checks that ParticleDistributions
+        initialized correctly in different circumstances.
+        """
+        dim = 5
+        n_particles = 100
+        particle_weights = np.random.rand(dim)
+        particle_weights = particle_weights / np.sum(particle_weights)
+        particle_locations = np.random.rand(n_particles, dim)
+
+        dist1 = ParticleDistribution(dim=dim)
+        dist2 = ParticleDistribution(
+            particle_weights=particle_weights,
+            particle_locations=particle_locations
+        )
+
+        assert(dist1.n_particles == 1)
+        assert(dist1.n_rvs == dim)
+        assert_almost_equal(dist1.sample(3), np.zeros((3, dim)))
+
+        assert(dist2.n_particles == n_particles)
+        assert(dist2.n_rvs == dim)
+        assert(dist1.sample(3).shape == (3,dim))
+
 class TestInterpolatedUnivariateDistribution(DerandomizedTestCase):
     """
     Tests ``InterpolatedUnivariateDistribution``
@@ -573,7 +605,7 @@ class TestInterpolatedUnivariateDistribution(DerandomizedTestCase):
         has the right moments.
         """
 
-        # Interpolate the normal distribution because we 
+        # Interpolate the normal distribution because we
         # know the moments
         dist = InterpolatedUnivariateDistribution(
             scipy.stats.norm.pdf, 1, 1500
@@ -600,7 +632,7 @@ class TestPostselectedDistribution(DerandomizedTestCase):
 
     def test_postselected_validity(self):
         """
-        Distributions: Checks that the postselected 
+        Distributions: Checks that the postselected
         samples are valid.
         """
 
@@ -617,8 +649,8 @@ class TestPostselectedDistribution(DerandomizedTestCase):
 
     def test_postselected_fails(self):
         """
-        Distributions: Checks that the postselected 
-        fails to generate enough points with a 
+        Distributions: Checks that the postselected
+        fails to generate enough points with a
         difficult constraint.
         """
 
@@ -691,4 +723,3 @@ class TestConstrainedSumDistribution(DerandomizedTestCase):
         dist = ConstrainedSumDistribution(unif, 3)
 
         assert(dist.n_rvs == 2)
-

--- a/src/qinfer/tests/test_distributions.py
+++ b/src/qinfer/tests/test_distributions.py
@@ -684,6 +684,36 @@ class TestParticleDistribution(DerandomizedTestCase):
         #TODO: test that est_kl_divergence does more than not fail
         dist1.est_kl_divergence(dist2)
 
+    def test_clustering(self):
+        """
+        Distributions: Tests that clustering works.
+        """
+
+        dim = 3
+        n_particles = 1000
+        # make two multivariate normal clusters
+        mu1 = 50+np.zeros(dim)
+        mu2 = -50+np.zeros(dim)
+        cov = np.random.randn(dim,dim)
+        cov = np.dot(cov,cov.T)
+        particle_locations = np.concatenate([
+            np.random.multivariate_normal(mu1, cov, int(n_particles/2)),
+            np.random.multivariate_normal(mu2, cov, int(n_particles/2))
+        ])
+        particle_weights = np.ones(n_particles)
+
+        dist = ParticleDistribution(
+            particle_weights=particle_weights,
+            particle_locations=particle_locations
+        )
+
+        # TODO: do more than check these don't fail (I didn't have time
+        # to figure out the undocumented code.)
+        dist.est_cluster_moments()
+        dist.est_cluster_covs()
+        dist.est_cluster_metric()
+
+
 
 class TestInterpolatedUnivariateDistribution(DerandomizedTestCase):
     """

--- a/src/qinfer/tests/test_region_estimates.py
+++ b/src/qinfer/tests/test_region_estimates.py
@@ -35,7 +35,7 @@ from numpy.testing import assert_equal, assert_almost_equal, assert_array_less
 
 from qinfer.abstract_model import FiniteOutcomeModel
 from qinfer.tests.base_test import DerandomizedTestCase, MockModel
-from qinfer.distributions import MultivariateNormalDistribution
+from qinfer.distributions import MultivariateNormalDistribution, ParticleDistribution
 from qinfer.smc import SMCUpdater
 
 ## FUNCTIONS ##################################################################
@@ -50,7 +50,7 @@ def unique_rows(a):
 
 ## CLASSES ####################################################################
 
-class TestCredibleRegions(DerandomizedTestCase):
+class TestSMCCredibleRegions(DerandomizedTestCase):
 
     N_PARTICLES = 10000
     N_MPS = 4
@@ -67,11 +67,11 @@ class TestCredibleRegions(DerandomizedTestCase):
         # with the desired normal distribution.
         u = SMCUpdater(MockModel(self.N_MPS), self.N_PARTICLES, dist)
 
-        # first check that 0.95 confidence points consume 0.9 confidence points 
+        # first check that 0.95 confidence points consume 0.9 confidence points
         points1 = u.est_credible_region(level=0.95)
         points2 = u.est_credible_region(level=0.9)
         assert_almost_equal(
-            np.sort(unique_rows(np.concatenate([points1, points2])), axis=0), 
+            np.sort(unique_rows(np.concatenate([points1, points2])), axis=0),
             np.sort(points1, axis=0)
         )
 
@@ -79,7 +79,7 @@ class TestCredibleRegions(DerandomizedTestCase):
         points1 = u.est_credible_region(level=0.95, modelparam_slice=self.SLICE)
         points2 = u.est_credible_region(level=0.9, modelparam_slice=self.SLICE)
         assert_almost_equal(
-            np.sort(unique_rows(np.concatenate([points1, points2])), axis=0), 
+            np.sort(unique_rows(np.concatenate([points1, points2])), axis=0),
             np.sort(points1, axis=0)
         )
 
@@ -94,13 +94,13 @@ class TestCredibleRegions(DerandomizedTestCase):
 
         faces, vertices = u.region_est_hull(level=0.95)
 
-        # In this multinormal case, the convex hull surface 
+        # In this multinormal case, the convex hull surface
         # should be centered at MEAN
         assert_almost_equal(
-            np.round(np.mean(vertices, axis=0)), 
+            np.round(np.mean(vertices, axis=0)),
             np.round(self.MEAN)
         )
-        
+
         # And a lower level should result in a smaller hull
         # and therefore smaller sample variance
         faces2, vertices2 = u.region_est_hull(level=0.2)
@@ -122,7 +122,7 @@ class TestCredibleRegions(DerandomizedTestCase):
         # center of ellipse should be the mean of the multinormal
         assert_almost_equal(np.round(c), self.MEAN, 1)
 
-        # finally, the principal lengths of the ellipsoid 
+        # finally, the principal lengths of the ellipsoid
         # should be the same as COV
         _, QA, _ = np.linalg.svd(A)
         _, QC, _ = np.linalg.svd(self.COV)
@@ -130,7 +130,7 @@ class TestCredibleRegions(DerandomizedTestCase):
         assert_almost_equal(
             QA / np.linalg.norm(QA),
             QC / np.linalg.norm(QC),
-            1   
+            1
         )
 
     def test_in_credible_region(self):
@@ -145,7 +145,7 @@ class TestCredibleRegions(DerandomizedTestCase):
 
         # some points to test with
         test_points = np.random.multivariate_normal(self.MEAN, self.COV, self.N_PARTICLES)
-        
+
         # method='pce'
         results = [
             u.in_credible_region(test_points, level=0.9, method='pce'),
@@ -181,7 +181,159 @@ class TestCredibleRegions(DerandomizedTestCase):
         )
 
         # the mvee should be bigger than the convex hull.
-        # this passes iff all points in the ellipses are 
+        # this passes iff all points in the ellipses are
+        # also in the hulls.
+        assert_array_less(
+            np.hstack([x.astype('float') for x in results1]),
+            np.hstack([x.astype('float') for x in results2]) + 0.5
+        )
+
+        # check for no failures with slices.
+        u.in_credible_region(test_points[:100,self.SLICE], level=0.9, method='pce', modelparam_slice=self.SLICE)
+        u.in_credible_region(test_points[:100,self.SLICE], level=0.9, method='hpd-hull', modelparam_slice=self.SLICE)
+        u.in_credible_region(test_points[:100,self.SLICE], level=0.9, method='hpd-mvee', modelparam_slice=self.SLICE)
+
+        # check for no failures with single inputs
+        assert(u.in_credible_region(test_points[0,:], level=0.9, method='pce').size == 1)
+        assert(u.in_credible_region(test_points[0,:], level=0.9, method='hpd-hull').size == 1)
+        assert(u.in_credible_region(test_points[0,:], level=0.9, method='hpd-mvee').size == 1)
+
+class TestCredibleRegions(DerandomizedTestCase):
+
+    N_PARTICLES = 10000
+    N_MPS = 4
+    MEAN = np.array([2,3,5,7])
+    COV = np.array([[1,0,0,0.5],[0,1,0.2,0],[0,0.2,2,0],[0.5,0,0,1]])
+    SLICE = np.s_[:2]
+
+    def test_est_credible_region(self):
+        """
+        Tests that est_credible_region doesn't fail miserably
+        """
+        dist = MultivariateNormalDistribution(self.MEAN, self.COV)
+        u = ParticleDistribution(
+            particle_locations = dist.sample(self.N_PARTICLES),
+            particle_weights = np.ones(self.N_PARTICLES)/self.N_PARTICLES
+        )
+
+        # first check that 0.95 confidence points consume 0.9 confidence points
+        points1 = u.est_credible_region(level=0.95)
+        points2 = u.est_credible_region(level=0.9)
+        assert_almost_equal(
+            np.sort(unique_rows(np.concatenate([points1, points2])), axis=0),
+            np.sort(points1, axis=0)
+        )
+
+        # do the same thing with different slice
+        points1 = u.est_credible_region(level=0.95, modelparam_slice=self.SLICE)
+        points2 = u.est_credible_region(level=0.9, modelparam_slice=self.SLICE)
+        assert_almost_equal(
+            np.sort(unique_rows(np.concatenate([points1, points2])), axis=0),
+            np.sort(points1, axis=0)
+        )
+
+    def test_region_est_hull(self):
+        """
+        Tests that test_region_est_hull works
+        """
+        dist = MultivariateNormalDistribution(self.MEAN, self.COV)
+        u = ParticleDistribution(
+            particle_locations = dist.sample(self.N_PARTICLES),
+            particle_weights = np.ones(self.N_PARTICLES)/self.N_PARTICLES
+        )
+
+        faces, vertices = u.region_est_hull(level=0.95)
+
+        # In this multinormal case, the convex hull surface
+        # should be centered at MEAN
+        assert_almost_equal(
+            np.round(np.mean(vertices, axis=0)),
+            np.round(self.MEAN)
+        )
+
+        # And a lower level should result in a smaller hull
+        # and therefore smaller sample variance
+        faces2, vertices2 = u.region_est_hull(level=0.2)
+        assert_array_less(np.var(vertices2, axis=0), np.var(vertices, axis=0))
+
+    def test_region_est_ellipsoid(self):
+        """
+        Tests that region_est_ellipsoid works.
+        """
+
+        dist = MultivariateNormalDistribution(self.MEAN, self.COV)
+        u = ParticleDistribution(
+            particle_locations = dist.sample(self.N_PARTICLES),
+            particle_weights = np.ones(self.N_PARTICLES)/self.N_PARTICLES
+        )
+
+        # ask for a confidence level of 0.5
+        A, c = u.region_est_ellipsoid(level=0.5)
+
+        # center of ellipse should be the mean of the multinormal
+        assert_almost_equal(np.round(c), self.MEAN, 1)
+
+        # finally, the principal lengths of the ellipsoid
+        # should be the same as COV
+        _, QA, _ = np.linalg.svd(A)
+        _, QC, _ = np.linalg.svd(self.COV)
+        QA, QC = np.sqrt(QA), np.sqrt(QC)
+        assert_almost_equal(
+            QA / np.linalg.norm(QA),
+            QC / np.linalg.norm(QC),
+            1
+        )
+
+    def test_in_credible_region(self):
+        """
+        Tests that in_credible_region works.
+        """
+
+        dist = MultivariateNormalDistribution(self.MEAN, self.COV)
+        u = ParticleDistribution(
+            particle_locations = dist.sample(self.N_PARTICLES),
+            particle_weights = np.ones(self.N_PARTICLES)/self.N_PARTICLES
+        )
+
+        # some points to test with
+        test_points = np.random.multivariate_normal(self.MEAN, self.COV, self.N_PARTICLES)
+
+        # method='pce'
+        results = [
+            u.in_credible_region(test_points, level=0.9, method='pce'),
+            u.in_credible_region(test_points, level=0.84, method='pce'),
+            u.in_credible_region(test_points, level=0.5, method='pce'),
+        ]
+        assert_almost_equal(
+            np.array([np.mean(x.astype('float')) for x in results]),
+            np.array([0.9, 0.84, 0.5]),
+            3
+        )
+
+        # method='hpd-hull'
+        results1 = [
+            u.in_credible_region(test_points, level=0.9, method='hpd-hull'),
+            u.in_credible_region(test_points, level=0.84, method='hpd-hull'),
+            u.in_credible_region(test_points, level=0.5, method='hpd-hull'),
+        ]
+        assert_array_less(
+            np.array([0.9, 0.84, 0.5]),
+            np.array([np.mean(x.astype('float')) for x in results1])
+        )
+
+        # method='hpd-mvee'
+        results2 = [
+            u.in_credible_region(test_points, level=0.9, method='hpd-mvee'),
+            u.in_credible_region(test_points, level=0.84, method='hpd-mvee'),
+            u.in_credible_region(test_points, level=0.5, method='hpd-mvee'),
+        ]
+        assert_array_less(
+            np.array([0.9, 0.84, 0.5]),
+            np.array([np.mean(x.astype('float')) for x in results2])
+        )
+
+        # the mvee should be bigger than the convex hull.
+        # this passes iff all points in the ellipses are
         # also in the hulls.
         assert_array_less(
             np.hstack([x.astype('float') for x in results1]),


### PR DESCRIPTION
This PR simply adds the new distribution `ParticleDistribution` and corresponding tests. All methods and properties of `SMCUpdater` which were (in my opinion) relevant to a bare particle distribution were copied over (but left intact). This is the first step of #105. The next step, in my view, is to implement the hierarchy `ParticleDistribution`>`AbstractUpdater`>`SMCUpdater`.

It would be worthwhile for someone to compare the properties and methods of `ParticleDistribution` and `SMCUpdater` to check if my choices are appropriate and comprehensive.

[Sorry for all the whitespace changes my text editor did automatically]