### PR TITLE
Tests for Domains

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ description-file = README.rst
 [bdist_wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 python_files=tests/*.py
 python_classes=Test
 python_functions=*_test

--- a/src/qinfer/domains.py
+++ b/src/qinfer/domains.py
@@ -257,7 +257,12 @@ class RealDomain(Domain):
 
         :rtype: `bool`
         """
-        return np.all(points >= self._min) and np.all(points <= self._max) and np.all(np.real(points) == points)
+        if np.all(np.isreal(points)):
+            are_greater = np.all(np.greater_equal(points, self._min))
+            are_smaller = np.all(np.less_equal(points, self._max))
+            return  are_greater and are_smaller
+        else:
+            return False
 
 class IntegerDomain(Domain):
     """
@@ -382,13 +387,13 @@ class IntegerDomain(Domain):
 
         :rtype: `bool`
         """
-        if np.all(np.real(points) == points):
+        if np.all(np.isreal(points)):
             try:
                 are_integer = np.all(np.mod(points, 1) == 0)
             except TypeError:
                 are_integer = False
-            are_greater = np.all(points >= self._min)
-            are_smaller = np.all(points <= self._max)
+            are_greater = np.all(np.greater_equal(points, self._min))
+            are_smaller = np.all(np.less_equal(points, self._max))
             return  are_integer and are_greater and are_smaller
         else:
             return False
@@ -533,4 +538,6 @@ class MultinomialDomain(Domain):
         :rtype: `bool`
         """
         array_view = self.to_regular_array(points)
-        return np.all(array_view >= 0) and np.all(np.sum(array_view, axis=-1) == self.n_meas)
+        non_negative = np.all(np.greater_equal(array_view, 0))
+        correct_sum = np.all(np.sum(array_view, axis=-1) == self.n_meas)
+        return non_negative and correct_sum

--- a/src/qinfer/domains.py
+++ b/src/qinfer/domains.py
@@ -90,18 +90,18 @@ class Domain(with_metaclass(abc.ABCMeta, object)):
     @abc.abstractproperty
     def n_members(self):
         """
-        Returns the number of members in the domain if it 
+        Returns the number of members in the domain if it
         `is_finite`, otherwise, returns `np.inf`.
 
-        :type: ``int`` or ``np.inf`` 
+        :type: ``int`` or ``np.inf``
         """
         pass
 
     @abc.abstractproperty
     def example_point(self):
         """
-        Returns any single point guaranteed to be in the domain, but 
-        no other guarantees; useful for testing purposes. 
+        Returns any single point guaranteed to be in the domain, but
+        no other guarantees; useful for testing purposes.
         This is given as a size 1 ``np.array`` of type `dtype`.
 
         :type: ``np.ndarray``
@@ -111,9 +111,9 @@ class Domain(with_metaclass(abc.ABCMeta, object)):
     @abc.abstractproperty
     def values(self):
         """
-        Returns an `np.array` of type `dtype` containing 
+        Returns an `np.array` of type `dtype` containing
         some values from the domain.
-        For domains where `is_finite` is ``True``, all elements 
+        For domains where `is_finite` is ``True``, all elements
         of the domain will be yielded exactly once.
 
         :rtype: `np.ndarray`
@@ -136,7 +136,7 @@ class Domain(with_metaclass(abc.ABCMeta, object)):
     @abc.abstractmethod
     def in_domain(self, points):
         """
-        Returns ``True`` if all of the given points are in the domain, 
+        Returns ``True`` if all of the given points are in the domain,
         ``False`` otherwise.
 
         :param np.ndarray points: An `np.ndarray` of type `self.dtype`.
@@ -149,13 +149,13 @@ class Domain(with_metaclass(abc.ABCMeta, object)):
 
 class RealDomain(Domain):
     """
-    A domain specifying a contiguous (and possibly open ended) subset 
+    A domain specifying a contiguous (and possibly open ended) subset
     of the real numbers.
 
-    :param float min: A number specifying the lowest possible value of the 
+    :param float min: A number specifying the lowest possible value of the
         domain.
-    :param float max: A number specifying the largest possible value of the 
-        domain. 
+    :param float max: A number specifying the largest possible value of the
+        domain.
     """
 
     def __init__(self, min=-np.inf, max=np.inf):
@@ -167,7 +167,7 @@ class RealDomain(Domain):
     @property
     def min(self):
         """
-        Returns the minimum value of the domain. 
+        Returns the minimum value of the domain.
 
         :rtype: `float`
         """
@@ -175,12 +175,12 @@ class RealDomain(Domain):
     @property
     def max(self):
         """
-        Returns the maximum value of the domain. 
+        Returns the maximum value of the domain.
 
         :rtype: `float`
         """
         return self._max
-    
+
     @property
     def is_continuous(self):
         """
@@ -211,7 +211,7 @@ class RealDomain(Domain):
     @property
     def n_members(self):
         """
-        Returns the number of members in the domain if it 
+        Returns the number of members in the domain if it
         `is_finite`, otherwise, returns `None`.
 
         :type: ``np.inf``
@@ -221,8 +221,8 @@ class RealDomain(Domain):
     @property
     def example_point(self):
         """
-        Returns any single point guaranteed to be in the domain, but 
-        no other guarantees; useful for testing purposes. 
+        Returns any single point guaranteed to be in the domain, but
+        no other guarantees; useful for testing purposes.
         This is given as a size 1 ``np.array`` of type ``dtype``.
 
         :type: ``np.ndarray``
@@ -237,9 +237,9 @@ class RealDomain(Domain):
     @property
     def values(self):
         """
-        Returns an `np.array` of type `self.dtype` containing 
+        Returns an `np.array` of type `self.dtype` containing
         some values from the domain.
-        For domains where ``is_finite`` is ``True``, all elements 
+        For domains where ``is_finite`` is ``True``, all elements
         of the domain will be yielded exactly once.
 
         :rtype: `np.ndarray`
@@ -250,27 +250,27 @@ class RealDomain(Domain):
 
     def in_domain(self, points):
         """
-        Returns ``True`` if all of the given points are in the domain, 
+        Returns ``True`` if all of the given points are in the domain,
         ``False`` otherwise.
 
         :param np.ndarray points: An `np.ndarray` of type `self.dtype`.
 
         :rtype: `bool`
         """
-        return np.all(points >= self._min) and np.all(points <= self._max)
+        return np.all(points >= self._min) and np.all(points <= self._max) and np.all(np.real(points) == points)
 
 class IntegerDomain(Domain):
     """
-    A domain specifying a contiguous (and possibly open ended) subset 
-    of the integers. 
+    A domain specifying a contiguous (and possibly open ended) subset
+    of the integers.
 
-    Internally minimum and maximum are represented as 
+    Internally minimum and maximum are represented as
     floats in order to handle the case of infinite maximum, and minimums. The
-    integer conversion function will be applied to the min and max values. 
+    integer conversion function will be applied to the min and max values.
 
-    :param int min: A number specifying the lowest possible value of the 
-        domain.  
-    :param int max: A number specifying the largest possible value of the 
+    :param int min: A number specifying the lowest possible value of the
+        domain.
+    :param int max: A number specifying the largest possible value of the
         domain.
 
     Note: Yes, it is slightly unpythonic to specify `max` instead of `max`+1.
@@ -285,20 +285,20 @@ class IntegerDomain(Domain):
     @property
     def min(self):
         """
-        Returns the minimum value of the domain. 
+        Returns the minimum value of the domain.
 
         :rtype: `float` or `np.inf`
         """
-        return int(self._min) if not np.isinf(self._min) else self._min  
+        return int(self._min) if not np.isinf(self._min) else self._min
     @property
     def max(self):
         """
-        Returns the maximum value of the domain. 
+        Returns the maximum value of the domain.
 
         :rtype: `float` or `np.inf`
         """
         return int(self._max) if not np.isinf(self._max) else self._max
-    
+
 
     @property
     def is_continuous(self):
@@ -330,7 +330,7 @@ class IntegerDomain(Domain):
     @property
     def n_members(self):
         """
-        Returns the number of members in the domain if it 
+        Returns the number of members in the domain if it
         `is_finite`, otherwise, returns `np.inf`.
 
         :type: ``int`` or ``np.inf``
@@ -343,8 +343,8 @@ class IntegerDomain(Domain):
     @property
     def example_point(self):
         """
-        Returns any single point guaranteed to be in the domain, but 
-        no other guarantees; useful for testing purposes. 
+        Returns any single point guaranteed to be in the domain, but
+        no other guarantees; useful for testing purposes.
         This is given as a size 1 ``np.array`` of type ``dtype``.
 
         :type: ``np.ndarray``
@@ -359,9 +359,9 @@ class IntegerDomain(Domain):
     @property
     def values(self):
         """
-        Returns an `np.array` of type `self.dtype` containing 
+        Returns an `np.array` of type `self.dtype` containing
         some values from the domain.
-        For domains where ``is_finite`` is ``True``, all elements 
+        For domains where ``is_finite`` is ``True``, all elements
         of the domain will be yielded exactly once.
 
         :rtype: `np.ndarray`
@@ -375,26 +375,31 @@ class IntegerDomain(Domain):
 
     def in_domain(self, points):
         """
-        Returns ``True`` if all of the given points are in the domain, 
+        Returns ``True`` if all of the given points are in the domain,
         ``False`` otherwise.
 
         :param np.ndarray points: An `np.ndarray` of type `self.dtype`.
 
         :rtype: `bool`
         """
-        are_integer = np.all(np.mod(points,1) == 0)
-        are_greater = np.all(points >= self._min) 
-        are_smaller = np.all(points <= self._max)
-        return  are_integer and are_greater and are_smaller
-    
+        if np.all(np.real(points) == points):
+            try:
+                are_integer = np.all(np.mod(points, 1) == 0)
+            except TypeError:
+                are_integer = False
+            are_greater = np.all(points >= self._min)
+            are_smaller = np.all(points <= self._max)
+            return  are_integer and are_greater and are_smaller
+        else:
+            return False
 
 class MultinomialDomain(Domain):
     """
-    A domain specifying k-tuples of non-negative integers which 
+    A domain specifying k-tuples of non-negative integers which
     sum to a specific value.
 
     :param int n_meas: The sum of any tuple in the domain.
-    :param int n_elements: The number of elements in a tuple. 
+    :param int n_elements: The number of elements in a tuple.
     """
 
     def __init__(self, n_meas, n_elements=2):
@@ -419,7 +424,7 @@ class MultinomialDomain(Domain):
         :rtype: `int`
         """
         return self._n_elements
-    
+
 
     @property
     def is_continuous(self):
@@ -451,7 +456,7 @@ class MultinomialDomain(Domain):
     @property
     def n_members(self):
         """
-        Returns the number of members in the domain if it 
+        Returns the number of members in the domain if it
         `is_finite`, otherwise, returns `None`.
 
         :type: ``int``
@@ -461,20 +466,20 @@ class MultinomialDomain(Domain):
     @property
     def example_point(self):
         """
-        Returns any single point guaranteed to be in the domain, but 
-        no other guarantees; useful for testing purposes. 
+        Returns any single point guaranteed to be in the domain, but
+        no other guarantees; useful for testing purposes.
         This is given as a size 1 ``np.array`` of type ``dtype``.
 
         :type: ``np.ndarray``
         """
-        return np.array([([self.n_meas] + [0] * (self.n_elements-1))], dtype=self.dtype)
+        return np.array([([self.n_meas] + [0] * (self.n_elements-1),)], dtype=self.dtype)
 
     @property
     def values(self):
         """
-        Returns an `np.array` of type `self.dtype` containing 
+        Returns an `np.array` of type `self.dtype` containing
         some values from the domain.
-        For domains where ``is_finite`` is ``True``, all elements 
+        For domains where ``is_finite`` is ``True``, all elements
         of the domain will be yielded exactly once.
 
         :rtype: `np.ndarray`
@@ -483,32 +488,32 @@ class MultinomialDomain(Domain):
         # This code comes from Jared Goguen at http://stackoverflow.com/a/37712597/1082565
         partition_array = np.empty((self.n_members, self.n_elements), dtype=int)
         masks = np.identity(self.n_elements, dtype=int)
-        for i, c in enumerate(combinations_with_replacement(masks, self.n_meas)): 
+        for i, c in enumerate(combinations_with_replacement(masks, self.n_meas)):
             partition_array[i,:] = sum(c)
 
         # Convert to dtype before returning
         return self.from_regular_array(partition_array)
-        
+
     ## METHODS ##
 
     def to_regular_array(self, A):
         """
-        Converts from an array of type `self.dtype` to an array 
-        of type `int` with an additional index labeling the 
+        Converts from an array of type `self.dtype` to an array
+        of type `int` with an additional index labeling the
         tuple indeces.
 
         :param np.ndarray A: An `np.array` of type `self.dtype`.
 
         :rtype: `np.ndarray`
         """
-        # this could be a static method, but we choose to be consistent with 
+        # this could be a static method, but we choose to be consistent with
         # from_regular_array
         return A.view((int, len(A.dtype.names))).reshape(A.shape + (-1,))
 
     def from_regular_array(self, A):
         """
-        Converts from an array of type `int` where the last index 
-        is assumed to have length `self.n_elements` to an array 
+        Converts from an array of type `int` where the last index
+        is assumed to have length `self.n_elements` to an array
         of type `self.d_type` with one fewer index.
 
         :param np.ndarray A: An `np.array` of type `int`.
@@ -520,7 +525,7 @@ class MultinomialDomain(Domain):
 
     def in_domain(self, points):
         """
-        Returns ``True`` if all of the given points are in the domain, 
+        Returns ``True`` if all of the given points are in the domain,
         ``False`` otherwise.
 
         :param np.ndarray points: An `np.ndarray` of type `self.dtype`.
@@ -529,5 +534,3 @@ class MultinomialDomain(Domain):
         """
         array_view = self.to_regular_array(points)
         return np.all(array_view >= 0) and np.all(np.sum(array_view, axis=-1) == self.n_meas)
-
-    

--- a/src/qinfer/tests/base_test.py
+++ b/src/qinfer/tests/base_test.py
@@ -573,11 +573,11 @@ class ConcreteDomainTest(with_metaclass(abc.ABCMeta, object)):
             try:
                 assert(self.domain.in_domain(v))
             except AssertionError as e:
-                print('Current Value: {}'.format(v))
+                e.args += ('Current good value: {}'.format(v),)
                 raise e
         for v in self.bad_values:
             try:
                 assert(not self.domain.in_domain(v))
             except AssertionError as e:
-                print('Current Value: {}'.format(v))
+                e.args += ('Current bad value: {}'.format(v),)
                 raise e

--- a/src/qinfer/tests/base_test.py
+++ b/src/qinfer/tests/base_test.py
@@ -570,6 +570,14 @@ class ConcreteDomainTest(with_metaclass(abc.ABCMeta, object)):
         (self.values is tested elsewhere)
         """
         for v in self.good_values:
-            assert(self.in_domain(v))
+            try:
+                assert(self.domain.in_domain(v))
+            except AssertionError as e:
+                print('Current Value: {}'.format(v))
+                raise e
         for v in self.bad_values:
-            assert(not self.in_domain(v))
+            try:
+                assert(not self.domain.in_domain(v))
+            except AssertionError as e:
+                print('Current Value: {}'.format(v))
+                raise e

--- a/src/qinfer/tests/base_test.py
+++ b/src/qinfer/tests/base_test.py
@@ -5,7 +5,7 @@
 ##
 # © 2014 Chris Ferrie (csferrie@gmail.com) and
 #        Christopher E. Granade (cgranade@gmail.com)
-#     
+#
 # This file is a part of the Qinfer project.
 # Licensed under the AGPL version 3.
 ##
@@ -45,11 +45,11 @@ from contextlib import contextmanager
 
 def test_model(model, prior, expparams, stream=sys.stderr):
     """
-    Tests the given Simulatable instance for errors. Useful for debugging 
+    Tests the given Simulatable instance for errors. Useful for debugging
     new or third party models.
 
     :param model: Instance of Simulatable or a subclass thereof.
-    :param prior: Instance of Distribution, or any other class which 
+    :param prior: Instance of Distribution, or any other class which
         implements a function `sample` that returns valid modelparams.
     :param expparams: `np.ndarray` of experimental parameters to test with.
     :param stream: Stream to dump the results into, default is stderr.
@@ -71,7 +71,7 @@ def test_model(model, prior, expparams, stream=sys.stderr):
             return prior
         def instantiate_expparams(self):
             return expparams
-    
+
     test = unittest.TestSuite((TestGivenModel, ))
     runner = unittest.TextTestRunner(stream=stream)
     runner.run(test)
@@ -90,7 +90,7 @@ def assert_warns(category):
         warnings.simplefilter('always')
 
         yield
-    
+
     assert any([
         issubclass(warning.category, category) for warning in caught_warnings
     ]), "No warning of category {} raised.".format(category)
@@ -106,28 +106,28 @@ class MockModel(FiniteOutcomeModel):
     def __init__(self, n_mps=2):
         self._n_mps = n_mps
         super(MockModel, self).__init__()
-    
+
     @property
     def n_modelparams(self):
         return self._n_mps
-        
+
     @staticmethod
     def are_models_valid(modelparams):
         return np.ones((modelparams.shape[0], ), dtype=bool)
-        
+
     @property
     def is_n_outcomes_constant(self):
         return True
-        
+
     def n_outcomes(self, expparams):
         return 2
 
-        
+
     @property
     def expparams_dtype(self):
         return [('a', float), ('b', int)]
-        
-    
+
+
     def likelihood(self, outcomes, modelparams, expparams):
         super(MockModel, self).likelihood(outcomes, modelparams, expparams)
         pr0 = np.ones((modelparams.shape[0], expparams.shape[0])) / 2
@@ -162,7 +162,7 @@ class MockDirectView(object):
 
     def execute(self, code, silent=True, targets=None, block=None):
         exec(code)
-    
+
     def gather(self, key, dist='b', targets=None, block=None):
         raise NotImplementedError
 
@@ -194,21 +194,21 @@ class DerandomizedTestCase(unittest.TestCase):
     # We do this by using the fact that nosetests and unittest both call
     # the method named "setUp" (note the capitalization!) before each
     # test method.
-    
+
     def setUp(self):
         np.random.seed(0)
 
 class ConcreteSimulatableTest(with_metaclass(abc.ABCMeta, object)):
     """
-    Mixin of generic tests which can be run to test basic properties 
-    of any subclass of Simulatable. 
+    Mixin of generic tests which can be run to test basic properties
+    of any subclass of Simulatable.
     """
-    
+
     # FORCED PROPERTIES ##
 
-    # We use this abstract instantiate_* paradigm to ensure that the actual 
-    # property cannot change instances throughout the testing. Although 
-    # unlikely, this paranoid approach prevents subclasses from having 
+    # We use this abstract instantiate_* paradigm to ensure that the actual
+    # property cannot change instances throughout the testing. Although
+    # unlikely, this paranoid approach prevents subclasses from having
     # model return something different every time it is called!
 
     @abc.abstractproperty
@@ -303,8 +303,8 @@ class ConcreteSimulatableTest(with_metaclass(abc.ABCMeta, object)):
     @property
     def outcomes(self):
         """
-        Fixed set of outcomes to do tests with. If you have 
-        a weird model with different outcome dtypes, you 
+        Fixed set of outcomes to do tests with. If you have
+        a weird model with different outcome dtypes, you
         may want to set this property manually.
         """
         try:
@@ -317,7 +317,7 @@ class ConcreteSimulatableTest(with_metaclass(abc.ABCMeta, object)):
             if os.shape[0] > self.n_outcomes:
                 os = os[:self.n_outcomes]
             self._outcomes = os
-            
+
             return self._outcomes
 
 
@@ -335,10 +335,10 @@ class ConcreteSimulatableTest(with_metaclass(abc.ABCMeta, object)):
             repeat = repeat + 1
 
         outcomes = self.model.simulate_experiment(self.modelparams, self.expparams, repeat=repeat)
-        
+
         assert(outcomes.shape == (
             repeat,
-            self.n_models, 
+            self.n_models,
             self.n_expparams)
             )
 
@@ -347,10 +347,10 @@ class ConcreteSimulatableTest(with_metaclass(abc.ABCMeta, object)):
             domain = self.model.domain(self.expparams[idx_ep:idx_ep+1])[0]
             assert(domain.in_domain(outcomes[:,:,idx_ep].flatten()))
 
-    
+
     def test_update_timestep(self):
         """
-        Tests that update_timstep does not fail and 
+        Tests that update_timstep does not fail and
         has the right output format.
         """
 
@@ -358,7 +358,7 @@ class ConcreteSimulatableTest(with_metaclass(abc.ABCMeta, object)):
 
         assert(mps.shape == (
             self.n_models,
-            self.model.n_modelparams, 
+            self.model.n_modelparams,
             self.n_expparams)
             )
 
@@ -374,7 +374,7 @@ class ConcreteSimulatableTest(with_metaclass(abc.ABCMeta, object)):
 
     def test_domain(self):
         """
-        Tests that the domain property returns a list of 
+        Tests that the domain property returns a list of
         domains of the correct length
         """
         domains = self.model.domain(self.expparams)
@@ -384,7 +384,7 @@ class ConcreteSimulatableTest(with_metaclass(abc.ABCMeta, object)):
 
 class ConcreteModelTest(ConcreteSimulatableTest):
     """
-    Mixin of generic tests which can be run to test basic properties 
+    Mixin of generic tests which can be run to test basic properties
     of any subclass of Model.
     """
 
@@ -399,7 +399,7 @@ class ConcreteModelTest(ConcreteSimulatableTest):
 
     def test_canonicalize(self):
         """
-        Tests that canonicalize does not fail and that it 
+        Tests that canonicalize does not fail and that it
         returns valid models for the tester's specific modelparams.
         """
 
@@ -417,13 +417,13 @@ class ConcreteModelTest(ConcreteSimulatableTest):
 
         assert(L.shape == (
             self.n_outcomes,
-            self.n_models, 
+            self.n_models,
             self.n_expparams)
             )
 
 class ConcreteDifferentiableModelTest(ConcreteModelTest):
     """
-    Mixin of generic tests which can be run to test basic properties 
+    Mixin of generic tests which can be run to test basic properties
     of any subclass of Model.
     """
 
@@ -436,11 +436,11 @@ class ConcreteDifferentiableModelTest(ConcreteModelTest):
         """
 
         fisher = self.model.fisher_information(self.modelparams, self.expparams)
-        
+
         assert(fisher.shape == (
             self.model.n_modelparams,
-            self.model.n_modelparams, 
-            self.n_models, 
+            self.model.n_modelparams,
+            self.n_models,
             self.n_expparams))
 
     def test_score(self):
@@ -459,9 +459,117 @@ class ConcreteDifferentiableModelTest(ConcreteModelTest):
 
         # Dimensions must be correct
         assert(score.shape == (
-            self.model.n_modelparams, 
-            self.n_outcomes, 
-            self.n_models, 
+            self.model.n_modelparams,
+            self.n_outcomes,
+            self.n_models,
             self.n_expparams)
             )
-        
+
+class ConcreteDomainTest(with_metaclass(abc.ABCMeta, object)):
+    """
+    Mixin of generic tests which can be run to test basic properties
+    of any subclass of Domain.
+    """
+
+    # FORCED PROPERTIES ##
+
+    # We use this abstract instantiate_* paradigm to ensure that the actual
+    # property cannot change instances throughout the testing.
+
+    @abc.abstractproperty
+    def instantiate_domain(self):
+        """
+        Generates and returns an instance of the concrete Domain class being tested.
+        """
+        pass
+    @property
+    def domain(self):
+        """
+        Returns (a fixed) instance of the concrete Model class being tested.
+        """
+        try:
+            return self._domain
+        except AttributeError:
+            self._domain = self.instantiate_domain()
+            return self._domain
+
+    @abc.abstractproperty
+    def instantiate_good_values(self):
+        """
+        Returns a list of values in the domain.
+        """
+        pass
+    @property
+    def good_values(self):
+        """
+        Returns (a fixed) list of values in the domain.
+        """
+        try:
+            return self._good_values
+        except AttributeError:
+            self._good_values = self.instantiate_good_values()
+            return self._good_values
+
+    @abc.abstractproperty
+    def instantiate_bad_values(self):
+        """
+        Returns a list of values not in the domain.
+        """
+        pass
+    @property
+    def bad_values(self):
+        """
+        Returns (a fixed) list of values not in the domain.
+        """
+        try:
+            return self._bad_values
+        except AttributeError:
+            self._bad_values = self.instantiate_bad_values()
+            return self._bad_values
+
+
+    ## TESTS ##
+
+    def test_is_cts_or_is_descrete(self):
+        """
+        Tests that is_continuous is not is_discrete
+        """
+        assert(self.domain.is_continuous or not self.domain.is_continuous)
+        assert(self.domain.is_continuous is not self.domain.is_discrete)
+
+
+    def test_is_finite(self):
+        """
+        Tests that is_finite is bool and consistent
+        """
+
+        assert(self.domain.is_finite or not self.domain.is_finite)
+        if self.domain.is_finite:
+            assert(self.domain.is_discrete)
+
+    def test_example_point(self):
+        """
+        Tests that the example point is in the domain and has the right dtype
+        """
+        assert(self.domain.in_domain(self.domain.example_point))
+        assert_equal(self.domain.example_point, self.domain.example_point.astype(self.domain.dtype))
+
+
+    def test_values(self):
+        """
+        Tests that n_members is consistent
+        """
+        values = self.domain.values
+        if self.domain.n_members < np.inf:
+            assert(values.size == self.domain.n_members)
+        assert(self.domain.in_domain(values))
+
+    def test_in_domain(self):
+        """
+        Tests that good_values are in the domain and bad_values are not.
+        (self.values is tested elsewhere)
+        """
+        for v in self.good_values:
+            assert(self.in_domain(v))
+        for v in self.bad_values:
+            assert(not self.in_domain(v))

--- a/src/qinfer/tests/test_domains.py
+++ b/src/qinfer/tests/test_domains.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+##
+# test_domains.py: Checks that built-in instances of Domain work properly.
+##
+# © 2014 Chris Ferrie (csferrie@gmail.com) and
+#        Christopher E. Granade (cgranade@gmail.com)
+#
+# This file is a part of the Qinfer project.
+# Licensed under the AGPL version 3.
+##
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+## FEATURES ###################################################################
+
+from __future__ import absolute_import
+from __future__ import division # Ensures that a/b is always a float.
+from future.utils import with_metaclass
+
+## IMPORTS ####################################################################
+
+import numpy as np
+from numpy.testing import assert_equal, assert_almost_equal
+
+from qinfer.tests.base_test import (
+    DerandomizedTestCase,
+    ConcreteDomainTest
+)
+import abc
+from qinfer import (
+    Domain, RealDomain, IntegerDomain, MultinomialDomain
+)
+
+import unittest
+
+## SIMPLE TEST MODELS #########################################################
+
+class TestIntegerDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests IntegerDomain with all integers.
+    """
+
+    def instantiate_domain(self):
+        return IntegerDomain()
+    def instantiate_good_values(self):
+        [np.array([54]).astype(np.float), np.array([-32]).astype(np.int)]
+    def instantiate_bad_values(self):
+        [np.array([0.5]), np.array([1j])]

--- a/src/qinfer/tests/test_domains.py
+++ b/src/qinfer/tests/test_domains.py
@@ -45,7 +45,59 @@ from qinfer import (
 
 import unittest
 
-## SIMPLE TEST MODELS #########################################################
+## CONSTANTS ###################################################################
+
+WEIRDO = np.array([(1,2.,'jump')], dtype=[('foo', 'i4'),('bar', 'f4'), ('baz', 'S10')])
+
+## DOMAIN TESTS ################################################################
+
+class TestRealDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests RealDomain with all reals.
+    """
+
+    def instantiate_domain(self):
+        return RealDomain(min=-np.inf,max=np.inf)
+    def instantiate_good_values(self):
+        return [np.pi, np.array([2.1]).astype(np.int), np.array([-32.2,2,2.8])]
+    def instantiate_bad_values(self):
+        return [np.array([1j]), WEIRDO]
+
+class TestPositiveRealDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests RealDomain with all non-negative reals.
+    """
+
+    def instantiate_domain(self):
+        return RealDomain(min=0,max=np.inf)
+    def instantiate_good_values(self):
+        return [0, np.pi, np.array([2.1]).astype(np.int), np.array([32.2,2,2.8])]
+    def instantiate_bad_values(self):
+        return [-0.001, np.array([1j]), WEIRDO]
+
+class TestNegativeRealDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests RealDomain with all non-positive reals.
+    """
+
+    def instantiate_domain(self):
+        return RealDomain(min=-np.inf,max=0)
+    def instantiate_good_values(self):
+        return [0, -np.pi, np.array([-2.1]).astype(np.int), np.array([-32.2,-2,-2.8])]
+    def instantiate_bad_values(self):
+        return [0.001, np.array([1j]), WEIRDO]
+
+class TestBoundedRealDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests RealDomain with a closed interval.
+    """
+
+    def instantiate_domain(self):
+        return RealDomain(min=np.e,max=np.pi)
+    def instantiate_good_values(self):
+        return [np.pi, np.array([3]), np.array([np.e,3.13,2.8])]
+    def instantiate_bad_values(self):
+        return [3.15, np.array([1j]), WEIRDO]
 
 class TestIntegerDomain(ConcreteDomainTest, DerandomizedTestCase):
     """
@@ -53,8 +105,73 @@ class TestIntegerDomain(ConcreteDomainTest, DerandomizedTestCase):
     """
 
     def instantiate_domain(self):
-        return IntegerDomain()
+        return IntegerDomain(min=-np.inf,max=np.inf)
     def instantiate_good_values(self):
-        [np.array([54]).astype(np.float), np.array([-32]).astype(np.int)]
+        return [np.array([54]).astype(np.float), np.array([-32,2,2]).astype(np.int)]
     def instantiate_bad_values(self):
-        [np.array([0.5]), np.array([1j])]
+        return [np.array([0.5]), np.array([np.pi, 1]), 1j, WEIRDO]
+
+class TestPositiveIntegerDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests IntegerDomain with all non-negative integers.
+    """
+
+    def instantiate_domain(self):
+        return IntegerDomain(min=0,max=np.inf)
+    def instantiate_good_values(self):
+        return [3, np.array([54]).astype(np.float), np.array([0, 32,1,2]).astype(np.int)]
+    def instantiate_bad_values(self):
+        return [np.array([0.5]), np.array([-1, 1]), 1j, WEIRDO]
+
+class TestNegativeIntegerDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests IntegerDomain with all non-positive integers.
+    """
+
+    def instantiate_domain(self):
+        return IntegerDomain(min=-np.inf,max=0)
+    def instantiate_good_values(self):
+        return [-3, np.array([-54]).astype(np.float), np.array([0, -32,-1,-2]).astype(np.int)]
+    def instantiate_bad_values(self):
+        return [np.array([-0.5]), np.array([-1, 1]), 1j, WEIRDO]
+
+class TestFiniteIntegerDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests IntegerDomain with a finite integer range.
+    """
+
+    def instantiate_domain(self):
+        return IntegerDomain(min=-2,max=8)
+    def instantiate_good_values(self):
+        return [3, np.array([8]).astype(np.float), np.array([0, -2,1,2]).astype(np.int)]
+    def instantiate_bad_values(self):
+        return [np.array([0.5]), np.array([-5, 1]), 1j, WEIRDO]
+
+class TestMultinomialDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests MultinomialDomain.
+    """
+
+    def instantiate_domain(self):
+        return MultinomialDomain(5, n_elements=3)
+    def instantiate_good_values(self):
+        return [
+            np.array([([4,0,1],),], dtype=np.dtype([('l', np.int, 3)])),
+            np.array([([1,1,3],),([2,2,1],)], dtype=self.domain.dtype),
+            self.domain.from_regular_array(np.array([[1,0,4],[2,3,0]]))
+        ]
+    def instantiate_bad_values(self):
+        return [
+            np.array([([4,1,0,1],),], dtype=np.dtype([('l', np.int, 4)])),
+            np.array([([1,10,3],),([2,2,1],)], dtype=self.domain.dtype),
+            self.domain.from_regular_array(np.array([[-1,0,6],[2,3,0]]))
+        ]
+
+    def test_array_conversion(self):
+        arr1 = np.array([([1,1,3],)], dtype=self.domain.dtype)
+        arr2 = np.array([[1,1,3]])
+
+        assert_equal(self.domain.to_regular_array(arr1), arr2)
+        assert_equal(self.domain.from_regular_array(arr2), arr1)
+        assert_equal(self.domain.to_regular_array(self.domain.from_regular_array(arr2)), arr2)
+        assert_equal(self.domain.from_regular_array(self.domain.to_regular_array(arr1)), arr1)


### PR DESCRIPTION
This PR adds a fairly comprehensive set of tests for concrete classes inheriting from `Domain`. This caught one bug in `MultinomialDomain.example_point` due to a comma (fixed), and a couple of pretty obscure bugs, like reporting `1j` is in `RealDomain` since technically `1j<np.inf` (also fixed).

Note: Sorry, again, for all the trailing whitespace removal. My stupid (but nice in most other ways) text editor does this by default and without warning whenever you save a file. I have now figured out how to disable it.