### PR TITLE
Feature: ProductDomain

### DIFF
--- a/doc/source/apiref/domains.rst
+++ b/doc/source/apiref/domains.rst
@@ -32,6 +32,16 @@ Class Reference
 .. autoclass:: Domain
     :members:
     
+
+:class:`ProductDomain` - Cartesian product of multiple domains
+--------------------------------------------------------------
+
+Class Reference 
+~~~~~~~~~~~~~~~
+.. autoclass:: ProductDomain
+    :members:
+
+    
 :class:`RealDomain` - (A subset of) Real Numbers
 ------------------------------------------------
 

--- a/src/qinfer/domains.py
+++ b/src/qinfer/domains.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 
 from builtins import range
 from future.utils import with_metaclass
+from functools import reduce
 
 from operator import mul
 from scipy.special import binom
@@ -235,7 +236,7 @@ class ProductDomain(Domain):
         """
         separate_values = [domain.values for domain in self._domains]
         return np.concatenate([
-            join_struct_arrays(map(np.array, value)) 
+            join_struct_arrays(list(map(np.array, value))) 
             for value in product(*separate_values)
         ])
 

--- a/src/qinfer/domains.py
+++ b/src/qinfer/domains.py
@@ -152,8 +152,8 @@ class ProductDomain(Domain):
     """
     A domain made from the cartesian product of other domains.
 
-    :param Domain domains: ``Domain`` objects as separate arguments, 
-        or as a singe list of ``Domain``s.
+    :param Domain domains: ``Domain`` instances as separate arguments, 
+        or as a singe list of ``Domain`` instances.
     """
     def __init__(self, *domains):
         
@@ -268,7 +268,7 @@ class ProductDomain(Domain):
         corresponding to the factor domains into a single array 
         with the dtype of the ``ProductDomain``.
 
-        :param list array: A list of ``np.ndarray``s
+        :param list array: A list with each element of type ``np.ndarray``
 
         :rtype: `np.ndarray`
         """

--- a/src/qinfer/domains.py
+++ b/src/qinfer/domains.py
@@ -233,14 +233,11 @@ class ProductDomain(Domain):
 
         :rtype: `np.ndarray`
         """
-        if self.is_finite:
-            separate_values = [domain.values for domain in self._domains]
-            return np.concatenate([
-                join_struct_arrays(map(np.array, value)) 
-                for value in product(*separate_values)
-            ])
-        else:
-            return self.example_point
+        separate_values = [domain.values for domain in self._domains]
+        return np.concatenate([
+            join_struct_arrays(map(np.array, value)) 
+            for value in product(*separate_values)
+        ])
 
     ## METHODS ##
     

--- a/src/qinfer/tests/test_domains.py
+++ b/src/qinfer/tests/test_domains.py
@@ -40,7 +40,8 @@ from qinfer.tests.base_test import (
 )
 import abc
 from qinfer import (
-    Domain, RealDomain, IntegerDomain, MultinomialDomain
+    Domain, ProductDomain,
+    RealDomain, IntegerDomain, MultinomialDomain
 )
 
 import unittest
@@ -175,3 +176,97 @@ class TestMultinomialDomain(ConcreteDomainTest, DerandomizedTestCase):
         assert_equal(self.domain.from_regular_array(arr2), arr1)
         assert_equal(self.domain.to_regular_array(self.domain.from_regular_array(arr2)), arr2)
         assert_equal(self.domain.from_regular_array(self.domain.to_regular_array(arr1)), arr1)
+        
+        
+class TestIntegerIntegerProductDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests ProductDomain([IntegerDomain, IntegerDomain])
+    """
+    
+    def instantiate_domain(self):
+        return ProductDomain(
+            IntegerDomain(min=0,max=5), 
+            IntegerDomain(min=-2, max=2)
+        )
+    def instantiate_good_values(self):
+        return [
+            np.array([(0,0)], dtype=[('','<i8'),('','<i8')]),
+            np.array([(5,2),(0,-2)], dtype=[('','<i8'),('','<i8')])
+        ]
+    def instantiate_bad_values(self):
+        return [
+            np.array([(0.5,0)], dtype=[('','f8'),('','<i8')]),
+            np.array([(6,2),(0,-2)], dtype=[('','<i8'),('','<i8')])
+        ]
+
+    def test_array_conversion(self):
+        arr1 = np.array([(5,2),(0,-1)], dtype=[('','<i8'),('','<i8')])
+        arr2 = [np.array([5,0]), np.array([2,-1])]
+
+        assert_equal(self.domain.to_regular_arrays(arr1), arr2)
+        assert_equal(self.domain.from_regular_arrays(arr2), arr1)
+        assert_equal(self.domain.to_regular_arrays(self.domain.from_regular_arrays(arr2)), arr2)
+        assert_equal(self.domain.from_regular_arrays(self.domain.to_regular_arrays(arr1)), arr1)
+
+    #override
+    def test_is_finite(self):
+        assert(self.domain.is_finite)
+        assert(self.domain.is_discrete)
+
+class TestIntegerIntegerProductDomain2(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests ProductDomain([IntegerDomain, IntegerDomain])
+    """
+    
+    def instantiate_domain(self):
+        return ProductDomain(
+            IntegerDomain(min=0,max=5), 
+            IntegerDomain(min=-2, max=np.inf),
+            IntegerDomain(min=-np.inf, max=np.inf)
+        )
+    def instantiate_good_values(self):
+        return [
+            np.array([(0,0,0)], dtype=[('','<i8'),('','<i8'),('','<i8')]),
+            np.array([(5,2,0),(0,-2,10)], dtype=[('','<i8'),('','<i8'),('','<i8')])
+        ]
+    def instantiate_bad_values(self):
+        return [
+            np.array([(0.5,0,10)], dtype=[('','f8'),('','<i8'),('','<i8')]),
+            np.array([(6,2,10),(0,-2,10)], dtype=[('','<i8'),('','<i8'),('','<i8')])
+        ]
+        
+    #override
+    def test_is_finite(self):
+        assert(not self.domain.is_finite)
+        assert(self.domain.is_discrete)
+    
+class TestIntegerMultinomialProductDomain(ConcreteDomainTest, DerandomizedTestCase):
+    """
+    Tests ProductDomain([IntegerDomain, IntegerDomain])
+    """
+    
+    def instantiate_domain(self):
+        return ProductDomain(
+            IntegerDomain(min=0,max=5), 
+            MultinomialDomain(5, n_elements=3)
+        )
+    def instantiate_good_values(self):
+        return [
+            np.array([(0,[1,2,2])], dtype=[('','<i8'),('','<i8', 3)]),
+            np.array([(5,[5,0,0]),(0,[1,0,4])], dtype=[('','<i8'),('','<i8', 3)])
+        ]
+    def instantiate_bad_values(self):
+        return [
+            np.array([(-10,[1,2,2])], dtype=[('','<i8'),('k','<i8', 3)]),
+            np.array([(5,[-1,6,0]),(0,[1,0,4])], dtype=[('','<i8'),('k','<i8', 3)])
+        ]
+
+    def test_array_conversion(self):
+        arr1 = np.array([(5,[1,2,2]),(0,[5,0,0])], dtype=[('','<i8'),('k','<i8', 3)])
+        arr2 = [np.array([5,0]), np.array([([1,2,2],), ([5,0,0],)], dtype=[('k','<i8',3)])]
+
+        assert_equal(self.domain.to_regular_arrays(arr1), arr2)
+        assert_equal(self.domain.from_regular_arrays(arr2), arr1)
+        assert_equal(self.domain.to_regular_arrays(self.domain.from_regular_arrays(arr2)), arr2)
+        assert_equal(self.domain.from_regular_arrays(self.domain.to_regular_arrays(arr1)), arr1)
+    

--- a/src/qinfer/utils.py
+++ b/src/qinfer/utils.py
@@ -454,6 +454,48 @@ def pretty_time(secs, force_h=False, force_m=False):
 def safe_shape(arr, idx=0, default=1):
     shape = np.shape(arr)
     return shape[idx] if idx < len(shape) else default
+    
+def join_struct_arrays(arrays):
+    """
+    Takes a list of possibly structured arrays, concatenates their
+    dtypes, and returns one big array with that dtype. Does the 
+    inverse of ``separate_struct_array``.
+    
+    :param list arrays: List of ``np.ndarray``s
+    """
+    # taken from http://stackoverflow.com/questions/5355744/numpy-joining-structured-arrays
+    sizes = np.array([a.itemsize for a in arrays])
+    offsets = np.r_[0, sizes.cumsum()]
+    shape = arrays[0].shape
+    joint = np.empty(shape + (offsets[-1],), dtype=np.uint8)
+    for a, size, offset in zip(arrays, sizes, offsets):
+        joint[...,offset:offset+size] = np.atleast_1d(a).view(np.uint8).reshape(shape + (size,))
+    dtype = sum((a.dtype.descr for a in arrays), [])
+    return joint.ravel().view(dtype)
+    
+def separate_struct_array(array, dtypes):
+    """
+    Takes an array with a structured dtype, and separates it out into 
+    a list of arrays with dtypes coming from the input ``dtypes``.
+    Does the inverse of ``join_struct_arrays``.
+    
+    :param np.ndarray array: Structured array.
+    :param dtypes: List of ``np.dtype``, or just a ``np.dtype`` and the number of
+        them is figured out automatically by counting bytes.
+    """
+    try:
+        offsets = np.cumsum([np.dtype(dtype).itemsize for dtype in dtypes])
+    except TypeError:
+        dtype_size = np.dtype(dtypes).itemsize
+        num_fields = int(array.nbytes / (array.size * dtype_size))
+        offsets = np.cumsum([dtype_size] * num_fields)
+        dtypes = [dtypes] * num_fields
+    offsets = np.concatenate([[0], offsets]).astype(int)
+    uint_array = array.view(np.uint8).reshape(array.shape + (-1,))
+    return [
+        uint_array[..., offsets[idx]:offsets[idx+1]].flatten().view(dtype)
+        for idx, dtype in enumerate(dtypes)
+    ]
 
     
 #==============================================================================


### PR DESCRIPTION
This PR adds a new domain called `ProductDomain` which takes the cartesian product of any number of factor domains. This is done using numpy structured dtypes, so you can, for example, take the product of `MultinomialDomain` and `RealDomain` and end up with a dtype like `[('k', int, 3), ('f1', float)]`.

This PR should be merged after #116 and #115.