### PR TITLE
Feature: Lui-West default number of particles

### DIFF
--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -198,7 +198,8 @@ class LiuWestResampler(Resampler):
     """
     def __init__(self,
             a=0.98, h=None, maxiter=1000, debug=False, postselect=True,
-            zero_cov_comp=1e-10, default_n_particles=None,
+            zero_cov_comp=1e-10, 
+            default_n_particles=None,
             kernel=np.random.randn
         ):
         self._default_n_particles = default_n_particles

--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -182,10 +182,10 @@ class LiuWestResampler(Resampler):
         has zero norm.
     :param callable kernel: Callable function ``kernel(*shape)`` that returns samples
         from a resampling distribution with mean 0 and variance 1.
-    :param int n_particles: The default number of particles to draw during
+    :param int default_n_particles: The default number of particles to draw during
         a resampling action. If ``None``, the number of redrawn particles 
-        redrawn will be equal to the number of particle given.
-        This value of ``n_particles`` can be overridden by any integer
+        redrawn will be equal to the number of particles given.
+        The value of ``default_n_particles`` can be overridden by any integer
         value of ``n_particles`` given to ``__call__``.
         
         
@@ -198,10 +198,10 @@ class LiuWestResampler(Resampler):
     """
     def __init__(self,
             a=0.98, h=None, maxiter=1000, debug=False, postselect=True,
-            zero_cov_comp=1e-10, n_particles=None,
+            zero_cov_comp=1e-10, default_n_particles=None,
             kernel=np.random.randn
         ):
-        self._default_n_particles = n_particles
+        self._default_n_particles = default_n_particles
         self.a = a # Implicitly calls the property setter below to set _h.
         if h is not None:
             self._override_h = True

--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -182,6 +182,12 @@ class LiuWestResampler(Resampler):
         has zero norm.
     :param callable kernel: Callable function ``kernel(*shape)`` that returns samples
         from a resampling distribution with mean 0 and variance 1.
+    :param int n_particles: The default number of particles to draw during
+        a resampling action. If ``None``, the number of redrawn particles 
+        redrawn will be equal to the number of particle given.
+        This value of ``n_particles`` can be overridden by any integer
+        value of ``n_particles`` given to ``__call__``.
+        
         
     .. warning::
     
@@ -192,9 +198,10 @@ class LiuWestResampler(Resampler):
     """
     def __init__(self,
             a=0.98, h=None, maxiter=1000, debug=False, postselect=True,
-            zero_cov_comp=1e-10,
+            zero_cov_comp=1e-10, n_particles=None,
             kernel=np.random.randn
         ):
+        self._default_n_particles = n_particles
         self.a = a # Implicitly calls the property setter below to set _h.
         if h is not None:
             self._override_h = True
@@ -244,7 +251,10 @@ class LiuWestResampler(Resampler):
             cov = precomputed_cov
         
         if n_particles is None:
-            n_particles = l.shape[0]
+            if self._default_n_particles is None:
+                n_particles = l.shape[0]
+            else:
+                n_particles = self._default_n_particles
         
         # parameters in the Liu and West algorithm            
         a, h = self._a, self._h

--- a/src/qinfer/smc.py
+++ b/src/qinfer/smc.py
@@ -145,7 +145,7 @@ class SMCUpdater(Distribution):
             self.resampler = qinfer.resamplers.LiuWestResampler(a=resample_a)
         else:
             if resampler is None:
-                self.resampler = qinfer.resamplers.LiuWestResampler()
+                self.resampler = qinfer.resamplers.LiuWestResampler(n_particles=n_particles)
             else:
                 self.resampler = resampler
 

--- a/src/qinfer/smc.py
+++ b/src/qinfer/smc.py
@@ -145,7 +145,7 @@ class SMCUpdater(Distribution):
             self.resampler = qinfer.resamplers.LiuWestResampler(a=resample_a)
         else:
             if resampler is None:
-                self.resampler = qinfer.resamplers.LiuWestResampler(n_particles=n_particles)
+                self.resampler = qinfer.resamplers.LiuWestResampler(default_n_particles=n_particles)
             else:
                 self.resampler = resampler
 


### PR DESCRIPTION
This PR adds a parameter to the Lui-West resampler called `default_n_particles` which optionally stores a default number of particles to draw. Furthermore, `SMCUpdater` has the default behaviour of setting `default_n_particles` of the `resampler` to the `__init__` input `n_particles`.

To the best of my knowledge, this should have no side-effects at present because (currently) the resampler is the only thing that changes the number of particles in the whole qinfer library.

The idea here is to allow `canonicalize` and `update_timestep` to drop particles (ala rejection filtering) without affecting the long-term stability. For example, if `update_timestep` takes particles outside of the allowed region, one of the most sensible things to do is drop them; trying to reflect them back in or something will probably have side-effects. Criticism of this PR welcome.