### PR TITLE
Update travis config for QuTiP 4.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       # QuTiP builds are currently broken under very old versions
       # of GCC, such as are installed by default with Travis CI.
       - gcc-4.8
+      - g++-4.8
       - texlive
       - texlive-latex-extra
       - texlive-fonts-extra


### PR DESCRIPTION
With the release of QuTiP 4.1 and its use of C++ features, we need to add ``g++`` as a build dependency on Travis to make sure we can compile the qutip package correctly. This should fix build errors seen in #125  and #126. Starting the PR to trigger builds and test whether it works.