### PR TITLE
WIP: Citation metadata w/ duecredit

### DIFF
--- a/doc/source/guide/citing.rst
+++ b/doc/source/guide/citing.rst
@@ -81,11 +81,44 @@ called by your script. For example, if your project can be run as
 
     $ python -m duecredit script.py
 
-This will create a file called ``.duecredit.p`` containing a representation
+Alternatively, it may be more reliable to use environment variables to turn
+on `duecredit`_ collection, since this approach also works with Jupyter Notebook::
+
+    $ export DUECREDIT_ENABLE=yes # Bash
+    PS> $Env:DUECREDIT_ENABLE = "yes" # PowerShell
+
+In either case, this will create a file called ``.duecredit.p`` containing a representation
 of your bibliography. To print it out in BibTeX form, use the summary functionality
 of `duecredit`_::
 
     $ duecredit summary --format=bibtex
+
+Note that this summary will also include projects such as NumPy and SciKit-Learn
+that are supported by `duecredit`_, as well as any other projects which natively
+host citation metadata through `duecredit`_.  For example::
+
+    $ export DUECREDIT_ENABLE=yes
+    $ ipython
+    In [1]: import qinfer as qi
+    In [2]: exit
+
+    DueCredit Report:
+    - Scientific tools library / numpy (v 1.11.1) [1]
+    - Bayesian inference for quantum information / qinfer (v 1.0) [2]
+    - Machine Learning library / sklearn (v 0.17.1) [3]
+        - Affinity propagation clustering algorithm / sklearn.cluster.affinity_propagation_ (v 0.17.1) [4]
+
+    3 packages cited
+    1 module cited
+    0 functions cited
+
+    References
+    ----------
+
+    [1] Van Der Walt, S., Colbert, S.C. & Varoquaux, G., 2011. The NumPy array: a structure for efficient numerical computation. Computing in Science & Engineering, 13(2), pp.22–30.
+    [2] Granade, C. et al., 2016. QInfer: Statistical Inference Software for Quantum Applications. arXiv:1610.00336 [physics, physics:quant-ph, stat].
+    [3] Pedregosa, F. et al., 2011. Scikit-learn: Machine learning in Python. The Journal of Machine Learning Research, 12, pp.2825–2830.
+    [4] Frey, B.J. & Dueck, D., 2007. Clustering by Passing Messages Between Data Points. Science, 315(5814), pp.972–976.
 
 For more details on how to use `duecredit`_, please see their `documentation on
 GitHub <https://github.com/duecredit/duecredit/blob/master/README.md>`_.

--- a/doc/source/guide/citing.rst
+++ b/doc/source/guide/citing.rst
@@ -120,6 +120,19 @@ host citation metadata through `duecredit`_.  For example::
     [3] Pedregosa, F. et al., 2011. Scikit-learn: Machine learning in Python. The Journal of Machine Learning Research, 12, pp.2825–2830.
     [4] Frey, B.J. & Dueck, D., 2007. Clustering by Passing Messages Between Data Points. Science, 315(5814), pp.972–976.
 
+The bibliography entries defined by QInfer are organized according to different
+*tags*, making it easier to filter through the results of `duecredit`_. In particular,
+QInfer defines the following citation tags:
+
+- ``implementation``: Concerns a software implementation of an algorithm or computation.
+- ``theory``: Concerns the initial proposal of an algorithm and other theory results.
+- ``experimental``: Concerns experimental demonstrations of an algorithm or procedure.
+
+These tags can be controlled using the ``DUECREDIT_REPORT_ALL`` and ``DUECREDIT_REPORT_TAGS``
+environment variables. By default, all tags by ``implementation`` are hidden, such that
+summaries of the collected bibliography describe which software implementations are used
+in the course of a project.
+
 For more details on how to use `duecredit`_, please see their `documentation on
 GitHub <https://github.com/duecredit/duecredit/blob/master/README.md>`_.
 

--- a/doc/source/guide/citing.rst
+++ b/doc/source/guide/citing.rst
@@ -1,0 +1,94 @@
+..
+    This work is licensed under the Creative Commons Attribution-
+    NonCommercial-ShareAlike 3.0 Unported License. To view a copy of this
+    license, visit http://creativecommons.org/licenses/by-nc-sa/3.0/ or send a
+    letter to Creative Commons, 444 Castro Street, Suite 900, Mountain View,
+    California, 94041, USA.
+    
+.. _citing_guide:
+    
+.. currentmodule:: qinfer
+
+Citing QInfer and Related Projects
+==================================
+
+Citing Released Versions
+------------------------
+
+If you use **QInfer** in your publication or presentation, we would appreciate it
+if you cited our work. We recommend citing **QInfer** by using the BibTeX
+entry::
+
+    @misc{qinfer-1_0,
+      author       = {Christopher Granade and
+                      Christopher Ferrie and
+                      Steven Casagrande and
+                      Ian Hincks and
+                      Michal Kononenko and
+                      Thomas Alexander and
+                      Yuval Sanders},
+      title        = {{QInfer}: Library for Statistical Inference in Quantum Information},
+      month        = september,
+      year         = 2016,
+      doi          = {10.5281/zenodo.157007},
+      url          = {http://dx.doi.org/10.5281/zenodo.157007}
+    }
+
+
+Pre-Release Versions
+--------------------
+
+If you wish to cite **QInfer** functionality that has not yet appeared in a
+released version, it may be helpful
+to cite a given SHA hash as listed on
+`GitHub <https://github.com/QInfer/python-qinfer/commits/master>`_ (the
+hashes of each commit are listed on the right hand side of the page).
+A recommended BibTeX entry for citing a particular commit is::
+
+    @misc{qinfer-prerelease,
+      author       = {Christopher Granade and
+                      Christopher Ferrie and
+                      Steven Casagrande and
+                      Ian Hincks and
+                      Michal Kononenko and
+                      Thomas Alexander and
+                      Yuval Sanders},
+      title        = {{QInfer}: Library for Statistical Inference in Quantum Information},
+      month        = may,
+      year         = 2016,
+      url =    "https://github.com/QInfer/python-qinfer/commit/bc3736c",
+      note =   {Version \texttt{bc3736c}.}
+    }
+
+In this example, ``bc3736c`` should be replaced by the
+particular commit being cited, and the date should be replaced by the date
+of that commit.
+
+Automatic Citation Collection
+-----------------------------
+
+QInfer also supports the use of the `duecredit`_ project to automatically
+collect citations for a bibliography. This support is still experimental,
+and may not yet generate complete bibliographies, so please manually check
+the resulting bibliography. In any case, to get started, install `duecredit`_::
+
+    $ pip install duecredit
+
+If your project then uses a script to generate and/or analyze data, then you
+can use `duecredit`_ to collect citations for Python modules and functions
+called by your script. For example, if your project can be run as
+`python script.py`, use the following command to collect a bibliography::
+
+    $ python -m duecredit script.py
+
+This will create a file called ``.duecredit.p`` containing a representation
+of your bibliography. To print it out in BibTeX form, use the summary functionality
+of `duecredit`_::
+
+    $ duecredit summary --format=bibtex
+
+For more details on how to use `duecredit`_, please see their `documentation on
+GitHub <https://github.com/duecredit/duecredit/blob/master/README.md>`_.
+
+
+.. _duecredit: https://github.com/duecredit/duecredit/

--- a/doc/source/guide/citing.rst
+++ b/doc/source/guide/citing.rst
@@ -122,11 +122,12 @@ host citation metadata through `duecredit`_.  For example::
 
 The bibliography entries defined by QInfer are organized according to different
 *tags*, making it easier to filter through the results of `duecredit`_. In particular,
-QInfer defines the following citation tags:
+QInfer uses the following citation tags, as defined in the `duecredit documentation
+<https://github.com/duecredit/duecredit/blob/master/README.md>`_:
 
-- ``implementation``: Concerns a software implementation of an algorithm or computation.
-- ``theory``: Concerns the initial proposal of an algorithm and other theory results.
-- ``experimental``: Concerns experimental demonstrations of an algorithm or procedure.
+- ``implementation``: The tagged function is an implementation of the cited work.
+- ``experiment``: Concerns experimental demonstrations of an algorithm or procedure. This tag
+  is similar to, but distinct from, the ``use`` tag defined by `duecredit`_.
 
 These tags can be controlled using the ``DUECREDIT_REPORT_ALL`` and ``DUECREDIT_REPORT_TAGS``
 environment variables. By default, all tags by ``implementation`` are hidden, such that

--- a/doc/source/guide/index.rst
+++ b/doc/source/guide/index.rst
@@ -24,4 +24,5 @@ User's Guide
     perf_testing
     parallel
     interop
+    citing
     

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -63,32 +63,7 @@ entry::
       url          = {http://dx.doi.org/10.5281/zenodo.157007}
     }
 
-If you wish to cite **QInfer** functionality that has not yet appeared in a
-released version, it may be helpful
-to cite a given SHA hash as listed on
-`GitHub <https://github.com/QInfer/python-qinfer/commits/master>`_ (the
-hashes of each commit are listed on the right hand side of the page).
-A recommended BibTeX entry for citing a particular commit is::
-
-    @misc{qinfer-1_0b4,
-      author       = {Christopher Granade and
-                      Christopher Ferrie and
-                      Steven Casagrande and
-                      Ian Hincks and
-                      Michal Kononenko and
-                      Thomas Alexander and
-                      Yuval Sanders},
-      title        = {{QInfer}: Library for Statistical Inference in Quantum Information},
-      month        = may,
-      year         = 2016,
-      url =    "https://github.com/QInfer/python-qinfer/commit/bc3736c",
-      note =   {Version \texttt{bc3736c}.}
-    }
-
-    
-In this example, ``bc3736c`` should be replaced by the
-particular commit being cited, and the date should be replaced by the date
-of that commit.
+For more details, please see :ref:`citing_guide`.
 
 Getting Started
 ===============

--- a/src/qinfer/__init__.py
+++ b/src/qinfer/__init__.py
@@ -26,6 +26,27 @@
 from __future__ import absolute_import
 from qinfer.version import version as __version__
 
+## CITATION METADATA ##########################################################
+
+from ._due import due, Doi, BibTeX
+due.cite(
+    BibTeX("""
+        @article{qinfer,
+            title = {{QInfer}: {Statistical} Inference Software for Quantum Applications},
+            eprinttype = {arxiv},
+            eprint = {1610.00336},
+            journal = {arXiv:1610.00336 [physics, physics:quant-ph, stat]},
+            author = {Granade, Christopher and Ferrie, Christopher and Hincks, Ian and Casagrande, Steven and Alexander, Thomas and Gross, Jonathan and Kononenko, Michal and Sanders, Yuval},
+            month = oct,
+            year = {2016}
+        }
+    """),
+    description="Bayesian inference for quantum information",
+    tags=["implementation"],
+    cite_module=True,
+    path="qinfer"
+)
+
 ## IMPORTS ####################################################################
 # These imports control what is made available by importing qinfer itself.
 

--- a/src/qinfer/__init__.py
+++ b/src/qinfer/__init__.py
@@ -29,6 +29,7 @@ from qinfer.version import version as __version__
 ## CITATION METADATA ##########################################################
 
 from ._due import due, Doi, BibTeX
+
 due.cite(
     BibTeX("""
         @article{qinfer,

--- a/src/qinfer/_due.py
+++ b/src/qinfer/_due.py
@@ -1,0 +1,73 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2016  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.5'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    cite = load = add = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if type(e).__name__ != 'ImportError':
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/src/qinfer/_due.py
+++ b/src/qinfer/_due.py
@@ -1,5 +1,6 @@
 # emacs: at the end of the file
 # ex: set sts=4 ts=4 sw=4 et:
+# pylint: skip-file
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
 """
 

--- a/src/qinfer/ale.py
+++ b/src/qinfer/ale.py
@@ -77,7 +77,7 @@ class ALEApproximateModel(DerivedModel):
     @due.dcite(
         Doi("10.1103/PhysRevLett.112.130402"),
         description="Adaptive likelihood estimation",
-        tags=["theory"]
+        tags=["implementation"]
     )
     def __init__(self, simulator,
         error_tol=1e-2, min_samp=10, samp_step=10,

--- a/src/qinfer/ale.py
+++ b/src/qinfer/ale.py
@@ -74,7 +74,7 @@ class ALEApproximateModel(DerivedModel):
         cause the algorithm to require more samples.
     """
     
-    @due.dcit(
+    @due.dcite(
         Doi("10.1103/PhysRevLett.112.130402"),
         description="Adaptive likelihood estimation",
         tags=["theory"]

--- a/src/qinfer/ale.py
+++ b/src/qinfer/ale.py
@@ -49,6 +49,7 @@ from qinfer.utils import binom_est_error, binom_est_p
 from qinfer.derived_models import DerivedModel
 from qinfer.abstract_model import Model, Simulatable, FiniteOutcomeModel
 from qinfer._exceptions import ApproximationWarning
+from qinfer._due import due, Doi
 
 ## CLASSES ####################################################################
 
@@ -73,6 +74,11 @@ class ALEApproximateModel(DerivedModel):
         cause the algorithm to require more samples.
     """
     
+    @due.dcit(
+        Doi("10.1103/PhysRevLett.112.130402"),
+        description="Adaptive likelihood estimation",
+        tags=["theory"]
+    )
     def __init__(self, simulator,
         error_tol=1e-2, min_samp=10, samp_step=10,
         est_hedge=0.509, adapt_hedge=0.509

--- a/src/qinfer/rb.py
+++ b/src/qinfer/rb.py
@@ -39,6 +39,7 @@ __all__ = [
 from itertools import starmap
 
 import numpy as np
+from qinfer._due import due, Doi
 from qinfer.abstract_model import FiniteOutcomeModel, DifferentiableModel
 
 from operator import mul
@@ -95,6 +96,11 @@ class RandomizedBenchmarkingModel(FiniteOutcomeModel, DifferentiableModel):
     """
     # TODO: add citations to the above docstring.
 
+    @due.dcite(
+        Doi("10.1088/1367-2630/17/1/013042"),
+        description="Accelerated randomized benchmarking",
+        tags=["theory"]
+    )
     def __init__(self, interleaved=False, order=0):
         self._il = interleaved
         if order != 0:

--- a/src/qinfer/rb.py
+++ b/src/qinfer/rb.py
@@ -99,7 +99,7 @@ class RandomizedBenchmarkingModel(FiniteOutcomeModel, DifferentiableModel):
     @due.dcite(
         Doi("10.1088/1367-2630/17/1/013042"),
         description="Accelerated randomized benchmarking",
-        tags=["theory"]
+        tags=["implementation"]
     )
     def __init__(self, interleaved=False, order=0):
         self._il = interleaved

--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -42,6 +42,7 @@ import numpy as np
 import scipy.linalg as la
 import warnings
 
+from ._due import due, BibTeX
 from .utils import outer_product, particle_meanfn, particle_covariance_mtx, sqrtm_psd
 
 from abc import ABCMeta, abstractmethod, abstractproperty
@@ -196,6 +197,23 @@ class LiuWestResampler(Resampler):
         resampler) if and only if :math:`a^2 + h^2 = 1`, as is set by the
         ``h=None`` keyword argument.
     """
+
+    @due.dcite(
+        BibTeX("""
+            @incollection{liu_combined_2001,
+                title = {Combined Parameter and State Estimation in Simulation-Based Filtering},
+                timestamp = {2013-01-28T21:57:35Z},
+                urldate = {2013-01-28},
+                booktitle = {Sequential {Monte Carlo} Methods in Practice},
+                publisher = {{Springer-Verlag, New York}},
+                author = {Liu, Jane and West, Mike},
+                editor = {De Freitas and Gordon, NJ},
+                year = {2001}
+            }
+        """),
+        description="Liu-West resampler",
+        tags=['theory']
+    )
     def __init__(self,
             a=0.98, h=None, maxiter=1000, debug=False, postselect=True,
             zero_cov_comp=1e-10, 

--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -212,7 +212,7 @@ class LiuWestResampler(Resampler):
             }
         """),
         description="Liu-West resampler",
-        tags=['theory']
+        tags=['implementation']
     )
     def __init__(self,
             a=0.98, h=None, maxiter=1000, debug=False, postselect=True,

--- a/src/qinfer/tomography/distributions.py
+++ b/src/qinfer/tomography/distributions.py
@@ -35,6 +35,7 @@ from __future__ import division
 
 ## IMPORTS ###################################################################
 
+from qinfer._due import due, Doi
 from qinfer import Distribution, SingleSampleMixin
 from qinfer.tomography.bases import gell_mann_basis, tensor_product_basis
 
@@ -213,6 +214,7 @@ class BCSZChoiDistribution(DensityOperatorDistribution):
     by the BCSZ prior [BCSZ09]_. The sampled states are normalized
     as states (trace 1).
     """
+    @due.dcite(Doi("10.1016/j.physleta.2008.11.043"), tags=['theory'])
     def __init__(self, basis, rank=None, enforce_tp=True):
         if isinstance(basis, int):
             basis = gell_mann_basis(basis)

--- a/src/qinfer/tomography/distributions.py
+++ b/src/qinfer/tomography/distributions.py
@@ -217,7 +217,7 @@ class BCSZChoiDistribution(DensityOperatorDistribution):
     @due.dcite(
         Doi("10.1016/j.physleta.2008.11.043"),
         description="BCSZ distribution",
-        tags=['theory']
+        tags=['implementation']
     )
     def __init__(self, basis, rank=None, enforce_tp=True):
         if isinstance(basis, int):

--- a/src/qinfer/tomography/distributions.py
+++ b/src/qinfer/tomography/distributions.py
@@ -214,7 +214,11 @@ class BCSZChoiDistribution(DensityOperatorDistribution):
     by the BCSZ prior [BCSZ09]_. The sampled states are normalized
     as states (trace 1).
     """
-    @due.dcite(Doi("10.1016/j.physleta.2008.11.043"), tags=['theory'])
+    @due.dcite(
+        Doi("10.1016/j.physleta.2008.11.043"),
+        description="BCSZ distribution",
+        tags=['theory']
+    )
     def __init__(self, basis, rank=None, enforce_tp=True):
         if isinstance(basis, int):
             basis = gell_mann_basis(basis)

--- a/src/qinfer/utils.py
+++ b/src/qinfer/utils.py
@@ -295,7 +295,7 @@ def ellipsoid_volume(A=None, invA=None):
 @due.dcite(
     Doi("10.1016/j.dam.2007.02.013"),
     description="Khachiyan algorithm",
-    tags=["theory"]
+    tags=["implementation"]
 )
 def mvee(points, tol=0.001):
     """

--- a/src/qinfer/utils.py
+++ b/src/qinfer/utils.py
@@ -46,6 +46,7 @@ from scipy.linalg import sqrtm
 
 from numpy.testing import assert_almost_equal
 
+from qinfer._due import due, Doi
 from qinfer._exceptions import ApproximationWarning
 
 ## FUNCTIONS ##################################################################
@@ -291,6 +292,11 @@ def ellipsoid_volume(A=None, invA=None):
     
     return Vn * la.det(sqrtm(invA))
 
+@due.dcite(
+    Doi("10.1016/j.dam.2007.02.013"),
+    description="Khachiyan algorithm",
+    tags=["theory"]
+)
 def mvee(points, tol=0.001):
     """
     Returns the minimum-volume enclosing ellipse (MVEE)


### PR DESCRIPTION
This WIP PR addresses #128 by adding citation metadata to ``__init__.py``. This citation is guarded with the tag ``["implementation"]``, with the idea that citations to underlying theory could be added to individual functions with the ``["theory"]`` tag.