### PR TITLE
Fix test_model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ install:
   # Before proceeding to install anything else, we debu
   # by making sure that the conda install didn't break matplotlib.
   - python -c "import matplotlib.pyplot as plt; print('Using MPL backend:'); print(plt.get_backend())" 
+  - pip install --upgrade pip
   - pip install -r requirements.txt
   # Before proceeding, we pause to list all installed conda and pip
   # packages for later debugging.

--- a/doc/source/apiref/test_models.rst
+++ b/doc/source/apiref/test_models.rst
@@ -39,4 +39,16 @@ built on top of QInfer.
 
 .. autoclass:: NDieModel
     :members:
+    
+Custom Models
+-------------
 
+Writing custom models is standard practice for QInfer users. 
+See :ref:`CustomModels`.
+
+.. currentmodule:: qinfer.tests.base_test
+
+:meth:`test_model` - Method to run suite of tests on a model instance
+---------------------------------------------------------------------
+
+.. autofunction:: test_model

--- a/doc/source/guide/models.rst
+++ b/doc/source/guide/models.rst
@@ -319,6 +319,8 @@ True
 >>> L.shape == (1, 100, 9)
 True
 
+.. _CustomModels:
+
 Implementing Custom Simulators and Models
 -----------------------------------------
 
@@ -414,6 +416,33 @@ True
 >>> D.shape == (2, 10000, 81)
 True
 
+Finally, we mention a useful tool for doing a set of
+tests on the custom model, which make sure its pieces are working as 
+expected. These tests look at things like data types and index dimensions of 
+various functions. They also plug the outputs of some methods into the inputs 
+of other methods, and so forth. Although they can't check the statistical 
+soundness of your model, if they all pass, you can be pretty confident 
+you won't run into weird indexing bugs in the future.
+
+We just need to pass :func:`~qinfer.tests.test_model` an instance of the 
+custom model, a prior that samples valid model parameters, and an array of valid 
+``expparams``.
+
+>>> from qinfer.tests import test_model
+>>> from qinfer import UniformDistribution
+>>> prior = UniformDistribution([[0,1],[0,1]])
+>>> test_model(mcm, prior, expparams)
+
+.. code-block:: None
+    :emphasize-lines: 1,2,3,4,5
+    
+    .......
+    ----------------------------------------------------------------------
+    Ran 7 tests in 0.013s
+
+    OK
+
+
 .. note::
 
     Creating ``expparams`` as an empty array and filling it by field name is a
@@ -456,4 +485,3 @@ which is discussed in more detail in :ref:`perf_testing_guide`. Roughly,
 this model causes the likeihood functions calculated by its underlying model
 to be subject to random noise, so that the robustness of an inference algorithm
 against such noise can be tested.
-

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(
     packages=[
         'qinfer',
         'qinfer._lib',
-        'qinfer.tomography'
+        'qinfer.tomography',
+        'qinfer.tests'
     ],
     keywords=['quantum', 'Bayesian', 'estimation'],
     description=

--- a/src/qinfer/tests/__init__.py
+++ b/src/qinfer/tests/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 from qinfer.tests import (
     test_distributions, base_test, test_precession_model)
+from qinfer.tests.base_test import test_model

--- a/src/qinfer/tests/base_test.py
+++ b/src/qinfer/tests/base_test.py
@@ -37,7 +37,7 @@ import abc
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import unittest
-from qinfer import Domain, FiniteOutcomeModel
+from qinfer import Domain, Model, Simulatable, FiniteOutcomeModel, DifferentiableModel
 
 from contextlib import contextmanager
 
@@ -56,11 +56,11 @@ def test_model(model, prior, expparams, stream=sys.stderr):
     """
 
     if isinstance(model, DifferentiableModel):
-        test_class = TestConcreteDifferentiableModel
+        test_class = ConcreteDifferentiableModelTest
     elif isinstance(model, Model):
-        test_class = TestConcreteModel
+        test_class = ConcreteModelTest
     elif isinstance(model, Simulatable):
-        test_class = TestConcreteSimulatable
+        test_class = ConcreteSimulatableTest
     else:
         raise ValueError("Given model has unrecognized type.")
 
@@ -72,9 +72,9 @@ def test_model(model, prior, expparams, stream=sys.stderr):
         def instantiate_expparams(self):
             return expparams
 
-    test = unittest.TestSuite((TestGivenModel, ))
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestGivenModel)
     runner = unittest.TextTestRunner(stream=stream)
-    runner.run(test)
+    runner.run(suite)
 
 @contextmanager
 def assert_warns(category):

--- a/src/qinfer/tests/test_test.py
+++ b/src/qinfer/tests/test_test.py
@@ -54,8 +54,6 @@ class TestTest(DerandomizedTestCase):
     def test_assert_warns_nowarn(self):
         with assert_warns(RuntimeWarning):
             pass
-            
-class TestTestModel(DerandomizedTestCase):
     
     def test_test_model_runs(self):
         model = MockModel()

--- a/src/qinfer/tests/test_test.py
+++ b/src/qinfer/tests/test_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 ##
-# test_smc.py: Checks that utilities for unit testing
+# test_test.py: Checks that utilities for unit testing
 #     actually run the tests we expect.
 ##
 # © 2014 Chris Ferrie (csferrie@gmail.com) and
@@ -37,7 +37,10 @@ import unittest
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 
-from qinfer.tests.base_test import DerandomizedTestCase, MockModel, assert_warns
+from qinfer import UniformDistribution
+from qinfer.tests.base_test import (
+    DerandomizedTestCase, MockModel, assert_warns, test_model
+)
 
 ## TESTS #####################################################################
 
@@ -51,3 +54,12 @@ class TestTest(DerandomizedTestCase):
     def test_assert_warns_nowarn(self):
         with assert_warns(RuntimeWarning):
             pass
+            
+class TestTestModel(DerandomizedTestCase):
+    
+    def test_test_model_runs(self):
+        model = MockModel()
+        prior = UniformDistribution(np.array([[10,12],[2,3]]))
+        eps = np.arange(10,20).astype(model.expparams_dtype)
+        test_model(model, prior, eps)
+        


### PR DESCRIPTION
The function `test_model` has apparently been broken for a while; it depended on some old names, etc. This fixes it and makes it visible as `qinfer.tests.test_model`, thereby addressing #131 too.