### PR TITLE
Feature custom meanfn

### DIFF
--- a/src/qinfer/distributions.py
+++ b/src/qinfer/distributions.py
@@ -325,20 +325,16 @@ class ParticleDistribution(Distribution):
     @staticmethod
     def particle_mean(weights, locations):
         r"""
-        Returns the mean of a function :math:`f` over model
-        parameters.
+        Returns the arithmetic mean of the `locations` weighted by `weights`
 
-        :param numpy.ndarray weights: Weights of each particle.
-        :param numpy.ndarray locations: Locations of each
-            particle.
-        :param callable fn: Function of model parameters to
-            take the mean of. If `None`, the identity function
-            is assumed.
+        :param numpy.ndarray weights: Weights of each particle in array of
+            shape ``(n_particles,)``.
+        :param numpy.ndarray locations: Locations of each particle in array
+            of shape ``(n_particles, n_modelparams)``
+        :rtype: :class:`numpy.ndarray`, shape ``(n_modelparams,)``.
+        :returns: An array containing the mean
         """
-        # We need the particle index to be the rightmost index, so that
-        # the two arrays align on the particle index as opposed to the
-        # modelparam index.
-        return np.sum(weights * locations.transpose([1, 0]), axis=1)
+        return np.dot(weights, locations)
 
     @classmethod
     def particle_covariance_mtx(cls, weights, locations):
@@ -346,16 +342,14 @@ class ParticleDistribution(Distribution):
         Returns an estimate of the covariance of a distribution
         represented by a given set of SMC particle.
 
-        :param weights: An array containing the weights of each
-            particle.
-        :param location: An array containing the locations of
-            each particle.
+        :param weights: An array of shape ``(n_particles,)`` containing
+            the weights of each particle.
+        :param location: An array of shape ``(n_particles, n_modelparams)``
+            containing the locations of each particle.
         :rtype: :class:`numpy.ndarray`, shape
             ``(n_modelparams, n_modelparams)``.
         :returns: An array containing the estimated covariance matrix.
         """
-        # TODO: add shapes to docstring.
-
         # Find the mean model vector, shape (n_modelparams, ).
         mu = cls.particle_mean(weights, locations)
 

--- a/src/qinfer/distributions.py
+++ b/src/qinfer/distributions.py
@@ -45,6 +45,7 @@ import abc
 from qinfer import utils as u
 from qinfer.metrics import rescaled_distance_mtx
 from qinfer.clustering import particle_clusters
+from qinfer._exceptions import ApproximationWarning
 
 import warnings
 
@@ -321,6 +322,76 @@ class ParticleDistribution(Distribution):
         ), len(cumsum_weights) - 1)]
 
     ## MOMENT FUNCTIONS ##
+    @staticmethod
+    def particle_mean(weights, locations):
+        r"""
+        Returns the mean of a function :math:`f` over model
+        parameters.
+
+        :param numpy.ndarray weights: Weights of each particle.
+        :param numpy.ndarray locations: Locations of each
+            particle.
+        :param callable fn: Function of model parameters to
+            take the mean of. If `None`, the identity function
+            is assumed.
+        """
+        # We need the particle index to be the rightmost index, so that
+        # the two arrays align on the particle index as opposed to the
+        # modelparam index.
+        return np.sum(weights * locations.transpose([1, 0]), axis=1)
+
+    @classmethod
+    def particle_covariance_mtx(cls, weights, locations):
+        """
+        Returns an estimate of the covariance of a distribution
+        represented by a given set of SMC particle.
+
+        :param weights: An array containing the weights of each
+            particle.
+        :param location: An array containing the locations of
+            each particle.
+        :rtype: :class:`numpy.ndarray`, shape
+            ``(n_modelparams, n_modelparams)``.
+        :returns: An array containing the estimated covariance matrix.
+        """
+        # TODO: add shapes to docstring.
+
+        # Find the mean model vector, shape (n_modelparams, ).
+        mu = cls.particle_mean(weights, locations)
+
+        # Transpose the particle locations to have shape
+        # (n_modelparams, n_particles).
+        xs = locations.transpose([1, 0])
+        # Give a shorter name to the particle weights, shape (n_particles, ).
+        ws = weights
+
+        cov = (
+            # This sum is a reduction over the particle index, chosen to be
+            # axis=2. Thus, the sum represents an expectation value over the
+            # outer product $x . x^T$.
+            #
+            # All three factors have the particle index as the rightmost
+            # index, axis=2. Using the Einstein summation convention (ESC),
+            # we can reduce over the particle index easily while leaving
+            # the model parameter index to vary between the two factors
+            # of xs.
+            #
+            # This corresponds to evaluating A_{m,n} = w_{i} x_{m,i} x_{n,i}
+            # using the ESC, where A_{m,n} is the temporary array created.
+            np.einsum('i,mi,ni', ws, xs, xs)
+            # We finish by subracting from the above expectation value
+            # the outer product $mu . mu^T$.
+            - np.dot(mu[..., np.newaxis], mu[np.newaxis, ...])
+        )
+
+        # The SMC approximation is not guaranteed to produce a
+        # positive-semidefinite covariance matrix. If a negative eigenvalue
+        # is produced, we should warn the caller of this.
+        assert np.all(np.isfinite(cov))
+        if not np.all(la.eig(cov)[0] >= 0):
+            warnings.warn('Numerical error in covariance estimation causing positive semidefinite violation.', ApproximationWarning)
+
+        return cov
 
     def est_mean(self):
         """
@@ -329,13 +400,8 @@ class ParticleDistribution(Distribution):
         :rtype: :class:`numpy.ndarray`, shape ``(n_mps,)``.
         :returns: An array containing the an estimate of the mean model vector.
         """
-        return np.sum(
-            # We need the particle index to be the rightmost index, so that
-            # the two arrays align on the particle index as opposed to the
-            # modelparam index.
-            self.particle_weights * self.particle_locations.transpose([1, 0]),
-            axis=1
-        )
+        return self.particle_mean(self.particle_weights,
+                                  self.particle_locations)
 
     def est_meanfn(self, fn):
         """
@@ -372,9 +438,8 @@ class ParticleDistribution(Distribution):
         :returns: An array containing the estimated covariance matrix.
         """
 
-        cov = u.particle_covariance_mtx(
-            self.particle_weights,
-            self.particle_locations)
+        cov = self.particle_covariance_mtx(self.particle_weights,
+                                           self.particle_locations)
 
         if corr:
             dstd = np.sqrt(np.diag(cov))
@@ -448,8 +513,8 @@ class ParticleDistribution(Distribution):
             yield (
                 cluster_label,
                 sum(w), # The zeroth moment is very useful here!
-                u.particle_meanfn(w, l, lambda x: x),
-                u.particle_covariance_mtx(w, l)
+                self.particle_mean(w, l),
+                self.particle_covariance_mtx(w, l)
             )
 
     def est_cluster_covs(self, cluster_opts=None):
@@ -467,7 +532,7 @@ class ParticleDistribution(Distribution):
         ws = cluster_moments['weight'][:, np.newaxis, np.newaxis]
 
         within_cluster_var = np.sum(ws * cluster_moments['cov'], axis=0)
-        between_cluster_var = u.particle_covariance_mtx(
+        between_cluster_var = self.particle_covariance_mtx(
             # Treat the cluster means as a new very small particle cloud.
             cluster_moments['weight'], cluster_moments['mean']
         )

--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -81,7 +81,7 @@ class Resampler(with_metaclass(ABCMeta, object)):
         :param np.ndarray precomputed_cov: Covariance of the original
             distribution, or `None` if this should be computed by the resampler.
 
-        :return ParticleDistribution: of each new particle.
+        :return ParticleDistribution: Resampled particle distribution
         """
 
 class ClusteringResampler(object):

--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -72,7 +72,8 @@ class Resampler(with_metaclass(ABCMeta, object)):
 
         :param Model model: Model from which the particles are drawn,
             used to define the valid region for resampling.
-        :param ParticleDistribution paricle_dist: The old particle distriution
+        :param ParticleDistribution paricle_dist: The particle distribution to
+            be resampled.
         :param int n_particles: Number of new particles to draw, or
             `None` to draw the same number as the original distribution.
         :param np.ndarray precomputed_mean: Mean of the original
@@ -319,6 +320,7 @@ class LiuWestResampler(Resampler):
             n_iters += 1
 
             # Set mu_i to a x_j + (1 - a) mu.
+            # TODO This is a particle mean :(
             mus[...] = a * l[js,:] + (1 - a) * mean
 
             # Draw x_i from N(mu_i, S).

--- a/src/qinfer/smc.py
+++ b/src/qinfer/smc.py
@@ -59,8 +59,8 @@ from qinfer.distributions import ParticleDistribution
 import qinfer.resamplers
 import qinfer.clustering
 import qinfer.metrics
-from qinfer.utils import outer_product, mvee, uniquify, particle_meanfn, \
-        particle_covariance_mtx, format_uncertainty, in_ellipsoid
+from qinfer.utils import outer_product, mvee, uniquify, format_uncertainty, \
+    in_ellipsoid
 from qinfer._exceptions import ApproximationWarning, ResamplerWarning
 
 try:

--- a/src/qinfer/smc.py
+++ b/src/qinfer/smc.py
@@ -55,7 +55,7 @@ from scipy.ndimage.filters import gaussian_filter1d
 
 from qinfer.abstract_model import DifferentiableModel
 from qinfer.metrics import rescaled_distance_mtx
-from qinfer.distributions import Distribution
+from qinfer.distributions import ParticleDistribution
 import qinfer.resamplers
 import qinfer.clustering
 import qinfer.metrics
@@ -84,7 +84,7 @@ logger.addHandler(logging.NullHandler())
 
 ## CLASSES #####################################################################
 
-class SMCUpdater(Distribution):
+class SMCUpdater(ParticleDistribution):
     r"""
     Creates a new Sequential Monte carlo updater, using the algorithm of
     [GFWC12]_.
@@ -118,16 +118,15 @@ class SMCUpdater(Distribution):
             zero_weight_policy='error', zero_weight_thresh=None,
             canonicalize=True
         ):
+        super(SMCUpdater, self).__init__(
+            particle_locations=np.zeros((0, model.n_modelparams)),
+            particle_weights=np.zeros((0,))
+        )
 
-        # Initialize zero-element arrays such that n_particles is always
-        # a valid property.
-        self.particle_locations = np.zeros((0, model.n_modelparams))
-        self.particle_weights = np.zeros((0,))
-        
         # Initialize metadata on resampling performance.
         self._resample_count = 0
         self._min_n_ess = n_particles
-        
+
         self.model = model
         self.prior = prior
 
@@ -157,41 +156,31 @@ class SMCUpdater(Distribution):
         self._data_record = []
         self._normalization_record = []
         self._resampling_divergences = [] if track_resampling_divergence else None
-        
+
         self._zero_weight_policy = zero_weight_policy
         self._zero_weight_thresh = (
             zero_weight_thresh
             if zero_weight_thresh is not None else
             10 * np.spacing(1)
         )
-        
+
         ## PARTICLE INITIALIZATION ##
         self.reset(n_particles)
 
     ## PROPERTIES #############################################################
 
     @property
-    def n_particles(self):
-        """
-        Returns the number of particles currently used in the sequential Monte
-        Carlo approximation.
-        
-        :type: `int`
-        """
-        return self.particle_locations.shape[0]
-
-    @property
     def resample_count(self):
         """
         Returns the number of times that the updater has resampled the particle
         approximation.
-        
+
         :type: `int`
         """
         # We wrap this in a property to prevent external resetting and to enable
         # a docstring.
         return self._resample_count
-        
+
     @property
     def just_resampled(self):
         """
@@ -206,36 +195,25 @@ class SMCUpdater(Distribution):
     def normalization_record(self):
         """
         Returns the normalization record.
-        
+
         :type: `float`
         """
         # We wrap this in a property to prevent external resetting and to enable
         # a docstring.
         return self._normalization_record
-        
+
     @property
     def log_total_likelihood(self):
         """
         Returns the log-likelihood of all the data collected so far.
-        
+
         Equivalent to::
-            
+
             np.sum(np.log(updater.normalization_record))
-        
+
         :type: `float`
         """
         return np.sum(np.log(self.normalization_record))
-        
-    @property
-    def n_ess(self):
-        """
-        Estimates the effective sample size (ESS) of the current distribution
-        over model parameters.
-
-        :type: `float`
-        :return: The effective sample size, given by :math:`1/\sum_i w_i^2`.
-        """
-        return 1 / (np.sum(self.particle_weights**2))
 
     @property
     def min_n_ess(self):
@@ -259,7 +237,7 @@ class SMCUpdater(Distribution):
         # We use [:] to force a new list to be made, decoupling
         # this property from the caller.
         return self._data_record[:]
-        
+
     @property
     def resampling_divergences(self):
         """
@@ -271,7 +249,7 @@ class SMCUpdater(Distribution):
         return self._resampling_divergences
 
     ## PRIVATE METHODS ########################################################
-    
+
     def _maybe_resample(self):
         """
         Checks the resample threshold and conditionally resamples.
@@ -289,12 +267,12 @@ class SMCUpdater(Distribution):
             pass
 
     ## INITIALIZATION METHODS #################################################
-    
+
     def reset(self, n_particles=None, only_params=None, reset_weights=True):
         """
         Causes all particle locations and weights to be drawn fresh from the
         initial prior.
-        
+
         :param int n_particles: Forces the size of the new particle set. If
             `None`, the size of the particle set is not changed.
         :param slice only_params: Resets only some of the parameters. Cannot
@@ -303,21 +281,21 @@ class SMCUpdater(Distribution):
         """
         # Particles are stored using two arrays, particle_locations and
         # particle_weights, such that:
-        # 
+        #
         # particle_locations[idx_particle, idx_modelparam] is the idx_modelparam
         #     parameter of the particle idx_particle.
         # particle_weights[idx_particle] is the weight of the particle
         #     idx_particle.
-        
+
         if n_particles is not None and only_params is not None:
             raise ValueError("Cannot set both n_particles and only_params.")
-        
+
         if n_particles is None:
             n_particles = self.n_particles
-        
+
         if reset_weights:
             self.particle_weights = np.ones((n_particles,)) / n_particles
-        
+
         if only_params is None:
             sl = np.s_[:, :]
             # Might as well make a new array if we're resetting everything.
@@ -364,10 +342,10 @@ class SMCUpdater(Distribution):
         # since NumPy broadcasting rules align on the right-most index.
         L = self.model.likelihood(outcomes, locs, expparams).transpose([0, 2, 1])
         hyp_weights = weights * L
-        
+
         # Sum up the weights to find the renormalization scale.
         norm_scale = np.sum(hyp_weights, axis=2)[..., np.newaxis]
-        
+
         # As a special case, check whether any entries of the norm_scale
         # are zero. If this happens, that implies that all of the weights are
         # zero--- that is, that the hypothicized outcome was impossible.
@@ -380,7 +358,7 @@ class SMCUpdater(Distribution):
         # and so we save the "fixed" norm_scale to a new array.
         fixed_norm_scale = norm_scale.copy()
         fixed_norm_scale[np.abs(norm_scale) < np.spacing(1)] = 1
-        
+
         # normalize
         norm_weights = hyp_weights / fixed_norm_scale
             # Note that newaxis is needed to align the two matrices.
@@ -421,10 +399,10 @@ class SMCUpdater(Distribution):
         self._data_record.append(outcome)
         self._just_resampled = False
 
-        # Perform the update. 
+        # Perform the update.
         weights, norm = self.hypothetical_update(outcome, expparams, return_normalization=True)
 
-        # Check for negative weights before applying the update.            
+        # Check for negative weights before applying the update.
         if not np.all(weights >= 0):
             warnings.warn("Negative weights occured in particle approximation. Smallest weight observed == {}. Clipping weights.".format(np.min(weights)), ApproximationWarning)
             np.clip(weights, 0, 1, out=weights)
@@ -451,10 +429,10 @@ class SMCUpdater(Distribution):
         # [outcome, experiment, particle], we need to strip off those two
         # indices first.
         self.particle_weights[:] = weights[0,0,:]
-        
+
         # Record the normalization
         self._normalization_record.append(norm[0][0])
-        
+
         # Update the particle locations according to the model's timestep.
         self.particle_locations = self.model.update_timestep(
             self.particle_locations, expparams
@@ -463,7 +441,7 @@ class SMCUpdater(Distribution):
         # Check if we need to update our min_n_ess attribute.
         if self.n_ess <= self._min_n_ess:
             self._min_n_ess = self.n_ess
-        
+
         # Resample if needed.
         if check_for_resample:
             self._maybe_resample()
@@ -504,7 +482,7 @@ class SMCUpdater(Distribution):
         """
         Forces the updater to perform a resampling step immediately.
         """
-        
+
         if self.just_resampled:
             warnings.warn(
                 "Resampling without additional data; this may not perform as "
@@ -521,7 +499,7 @@ class SMCUpdater(Distribution):
         if self._resampling_divergences is not None:
             old_locs = self.particle_locations.copy()
             old_weights = self.particle_weights.copy()
-            
+
         # Record the previous mean, cov if needed.
         if self._debug_resampling:
             old_mean = self.est_mean()
@@ -531,13 +509,15 @@ class SMCUpdater(Distribution):
         # algorithm.
         # We pass the model so that the resampler can check for validity of
         # newly placed particles.
-        self.particle_weights, self.particle_locations = \
-            self.resampler(self.model, self.particle_weights, self.particle_locations)
+        # FIXME This feels fishy. If we update particles elsewwhere
+        new_distribution = self.resampler(self.model, self)
+        self.particle_weights = new_distribution.particle_weights
+        self.particle_locations = new_distribution.particle_locations
 
         # Possibly canonicalize, if we've been asked to do so.
         if self._canonicalize:
             self.particle_locations[:, :] = self.model.canonicalize(self.particle_locations)
-        
+
         # Instruct the model to clear its cache, demoting any errors to
         # warnings.
         try:
@@ -550,7 +530,7 @@ class SMCUpdater(Distribution):
             self._resampling_divergences.append(
                 self._kl_divergence(old_locs, old_weights)
             )
-            
+
         # Report current and previous mean, cov.
         if self._debug_resampling:
             new_mean = self.est_mean()
@@ -560,110 +540,17 @@ class SMCUpdater(Distribution):
                 np.linalg.norm(new_cov - old_cov)
             ))
 
-    ## DISTRIBUTION CONTRACT ##################################################
-    
-    @property
-    def n_rvs(self):
-        """
-        The number of random variables described by the posterior distribution. 
-
-        :type int:
-        """
-        return self._model.n_modelparams
-        
-    def sample(self, n=1):
-        """
-        Returns samples from the current posterior distribution.
-
-        :param int n: The number of samples to draw.
-        :return: The sampled model parameter vectors.
-        :rtype: `~numpy.ndarray` of shape ``(n, updater.n_rvs)``.
-        """
-        cumsum_weights = np.cumsum(self.particle_weights)
-        return self.particle_locations[np.minimum(cumsum_weights.searchsorted(
-            np.random.random((n,)),
-            side='right'
-        ), len(cumsum_weights) - 1)]
-
-    ## ESTIMATION METHODS #####################################################
-
-    def est_mean(self):
-        """
-        Returns an estimate of the posterior mean model, given by the
-        expectation value over the current SMC approximation of the posterior
-        model distribution.
-        
-        :rtype: :class:`numpy.ndarray`, shape ``(n_modelparams,)``.
-        :returns: An array containing the an estimate of the mean model vector.
-        """
-        return np.sum(
-            # We need the particle index to be the rightmost index, so that
-            # the two arrays align on the particle index as opposed to the
-            # modelparam index.
-            self.particle_weights * self.particle_locations.transpose([1, 0]),
-            # The argument now has shape (n_modelparams, n_particles), so that
-            # the sum should collapse the particle index, 1.
-            axis=1
-        )
-        
-    def est_meanfn(self, fn):
-        """
-        Returns an estimate of the expectation value of a given function
-        :math:`f` of the model parameters, given by a sum over the current SMC
-        approximation of the posterior distribution over models.
-        
-        Here, :math:`f` is represented by a function ``fn`` that is vectorized
-        over particles, such that ``f(modelparams)`` has shape
-        ``(n_particles, k)``, where ``n_particles = modelparams.shape[0]``, and
-        where ``k`` is a positive integer.
-        
-        :param callable fn: Function implementing :math:`f` in a vectorized
-            manner. (See above.)
-        
-        :rtype: :class:`numpy.ndarray`, shape ``(k, )``.
-        :returns: An array containing the an estimate of the mean of :math:`f`.
-        """
-        
-        return np.einsum('i...,i...',
-            self.particle_weights, fn(self.particle_locations)
-        )
-
-    def est_covariance_mtx(self, corr=False):
-        """
-        Returns an estimate of the covariance of the current posterior model
-        distribution, given by the covariance of the current SMC approximation.
-
-        :param bool corr: If `True`, the covariance matrix is normalized
-            by the outer product of the square root diagonal of the covariance matrix
-            such that the correlation matrix is returned instead.
-        
-        :rtype: :class:`numpy.ndarray`, shape
-            ``(n_modelparams, n_modelparams)``.
-        :returns: An array containing the estimated covariance matrix.
-        """
-
-        cov = particle_covariance_mtx(
-            self.particle_weights,
-            self.particle_locations)
-
-        if corr:
-            dstd = np.sqrt(np.diag(cov))
-            cov /= (np.outer(dstd, dstd))
-
-        return cov
-
-
     def bayes_risk(self, expparams):
         r"""
         Calculates the Bayes risk for a hypothetical experiment, assuming the
         quadratic loss function defined by the current model's scale matrix
         (see :attr:`qinfer.abstract_model.Simulatable.Q`).
-        
+
         :param expparams: The experiment at which to compute the Bayes risk.
         :type expparams: :class:`~numpy.ndarray` of dtype given by the current
             model's :attr:`~qinfer.abstract_model.Simulatable.expparams_dtype` property,
             and of shape ``(1,)``
-            
+
         :return float: The Bayes risk for the current posterior distribution
             of the hypothetical experiment ``expparams``.
         """
@@ -682,18 +569,18 @@ class SMCUpdater(Distribution):
         N = N[:, :, 0] # Fix L.shape == (n_outcomes, n_particles).
 
         xs = self.particle_locations.transpose([1, 0]) # shape (n_mp, n_particles).
-        
+
         # In the following, we will use the subscript convention that
         # "o" refers to an outcome, "p" to a particle, and
         # "i" to a model parameter.
         # Thus, mu[o,i] is the sum over all particles of w[o,p] * x[i,p].
-    
+
         mu = np.transpose(np.tensordot(w,xs,axes=(1,1)))
         var = (
             # This sum is a reduction over the particle index and thus
             # represents an expectation value over the diagonal of the
             # outer product $x . x^T$.
-            
+
             np.transpose(np.tensordot(w,xs**2,axes=(1,1)))
             # We finish by subracting from the above expectation value
             # the diagonal of the outer product $mu . mu^T$.
@@ -704,17 +591,17 @@ class SMCUpdater(Distribution):
         # Q has shape (n_mp,), therefore rescale_var has shape (n_outcomes,).
         tot_norm = np.sum(N, axis=1)
         return np.dot(tot_norm.T, rescale_var)
-        
+
     def expected_information_gain(self, expparams):
         r"""
         Calculates the expected information gain for a hypothetical experiment.
-        
+
         :param expparams: The experiment at which to compute expected
             information gain.
         :type expparams: :class:`~numpy.ndarray` of dtype given by the current
             model's :attr:`~qinfer.abstract_model.Simulatable.expparams_dtype` property,
             and of shape ``(1,)``
-            
+
         :return float: The Bayes risk for the current posterior distribution
             of the hypothetical experiment ``expparams``.
         """
@@ -723,340 +610,42 @@ class SMCUpdater(Distribution):
         w, N = self.hypothetical_update(np.arange(nout), expparams, return_normalization=True)
         w = w[:, 0, :] # Fix w.shape == (n_outcomes, n_particles).
         N = N[:, :, 0] # Fix N.shape == (n_outcomes, n_particles).
-        
+
         # This is a special case of the KL divergence estimator (see below),
         # in which the other distribution is guaranteed to share support.
         #
         # KLD[idx_outcome] = Sum over particles(self * log(self / other[idx_outcome])
         # Est. KLD = E[KLD[idx_outcome] | outcomes].
-        
+
         KLD = np.sum(
             w * np.log(w / self.particle_weights ),
             axis=1 # Sum over particles.
         )
-        
+
         tot_norm = np.sum(N, axis=1)
         return np.dot(tot_norm, KLD)
-        
-    def est_entropy(self):
-        r"""
-        Estimates the entropy of the current posterior
-        as :math:`-\sum_i w_i \log w_i` where :math:`\{w_i\}`
-        is the set of particles with nonzero weight. 
-        """
-        nz_weights = self.particle_weights[self.particle_weights > 0]
-        return -np.sum(np.log(nz_weights) * nz_weights)
-    
-    def _kl_divergence(self, other_locs, other_weights, kernel=None, delta=1e-2):
-        """
-        Finds the KL divergence between this and another SMC-approximated
-        distribution by using a kernel density estimator to smooth over the
-        other distribution's particles.
-        """
-        if kernel is None:
-            kernel = scipy.stats.norm(loc=0, scale=1).pdf
-        
-        dist = qinfer.metrics.rescaled_distance_mtx(self, other_locs) / delta
-        K = kernel(dist)        
-        
-        return -self.est_entropy() - (1 / delta) * np.sum(
-            self.particle_weights * 
-            np.log(
-                np.sum(
-                    other_weights * K,
-                    axis=1 # Sum over the particles of ``other``.
-                )
-            ),
-            axis=0  # Sum over the particles of ``self``.
-        )  
-        
-    def est_kl_divergence(self, other, kernel=None, delta=1e-2):
-        """
-        Finds the KL divergence between this and another SMC-approximated
-        distribution by using a kernel density estimator to smooth over the
-        other distribution's particles.
 
-        :param SMCUpdater other: 
-        """
-        return self._kl_divergence(
-            other.particle_locations,
-            other.particle_weights,
-            kernel, delta
-        )
-        
-    ## CLUSTER ESTIMATION METHODS #############################################
-        
-    def est_cluster_moments(self, cluster_opts=None):
-        # TODO: document
-        
-        if cluster_opts is None:
-            cluster_opts = {}
-        
-        for cluster_label, cluster_particles in qinfer.clustering.particle_clusters(
-                self.particle_locations, self.particle_weights,
-                **cluster_opts
-            ):
-            
-            w = self.particle_weights[cluster_particles]
-            l = self.particle_locations[cluster_particles]
-            yield (
-                cluster_label,
-                sum(w), # The zeroth moment is very useful here!
-                particle_meanfn(w, l, lambda x: x),
-                particle_covariance_mtx(w, l)
-            )
-            
-    def est_cluster_covs(self, cluster_opts=None):
-        # TODO: document
-        
-        cluster_moments = np.array(
-            list(self.est_cluster_moments(cluster_opts)),
-            dtype=[
-                ('label', 'int'),
-                ('weight', 'float64'),
-                ('mean', '{}float64'.format(self.model.n_modelparams)),
-                ('cov', '{0},{0}float64'.format(self.model.n_modelparams)),
-            ])
-            
-        ws = cluster_moments['weight'][:, np.newaxis, np.newaxis]
-            
-        within_cluster_var = np.sum(ws * cluster_moments['cov'], axis=0)
-        between_cluster_var = particle_covariance_mtx(
-            # Treat the cluster means as a new very small particle cloud.
-            cluster_moments['weight'], cluster_moments['mean']
-        )
-        total_var = within_cluster_var + between_cluster_var
-        
-        return within_cluster_var, between_cluster_var, total_var
-        
-    def est_cluster_metric(self, cluster_opts=None):
-        """
-        Returns an estimate of how much of the variance in the current posterior
-        can be explained by a separation between *clusters*.
-        """
-        wcv, bcv, tv = self.est_cluster_covs(cluster_opts)
-        return np.diag(bcv) / np.diag(tv)
-        
-
-    ## REGION ESTIMATION METHODS ##############################################
-
-    def est_credible_region(self, level=0.95, return_outside=False, modelparam_slice=None):
-        """
-        Returns an array containing particles inside a credible region of a
-        given level, such that the described region has probability mass
-        no less than the desired level.
-        
-        Particles in the returned region are selected by including the highest-
-        weight particles first until the desired credibility level is reached.
-        
-        :param float level: Crediblity level to report.
-        :param bool return_outside: If `True`, the return value is a tuple
-            of the those particles within the credible region, and the rest
-            of the posterior particle cloud.
-        :param slice modelparam_slice: Slice over which model parameters
-            to consider.
-
-        :rtype: :class:`numpy.ndarray`, shape ``(n_credible, n_mps)``,
-            where ``n_credible`` is the number of particles in the credible
-            region and ``n_mps`` corresponds to the size of ``modelparam_slice``.
-             If ``return_outside`` is ``True``, this method instead 
-             returns tuple ``(inside, outside)`` where ``inside`` is as 
-             described above, and ``outside`` has shape ``(n_particles-n_credible, n_mps)``.
-        :return: An array of particles inside the estimated credible region. Or,
-            if ``return_outside`` is ``True``, both the particles inside and the
-            particles outside, as a tuple.
-        """
-
-        # which slice of modelparams to take
-        s_ = np.s_[modelparam_slice] if modelparam_slice is not None else np.s_[:]
-        mps = self.particle_locations[:, s_]
-        
-        # Start by sorting the particles by weight.
-        # We do so by obtaining an array of indices `id_sort` such that
-        # `particle_weights[id_sort]` is in descending order.
-        id_sort = np.argsort(self.particle_weights)[::-1]
-        
-        # Find the cummulative sum of the sorted weights.
-        cumsum_weights = np.cumsum(self.particle_weights[id_sort])
-        
-        # Find all the indices where the sum is less than level.
-        # We first find id_cred such that
-        # `all(cumsum_weights[id_cred] <= level)`.
-        id_cred = cumsum_weights <= level
-        # By construction, by adding the next particle to id_cred, it must be
-        # true that `cumsum_weights[id_cred] >= level`, as required.
-        id_cred[np.sum(id_cred)] = True
-        
-        # We now return a slice onto the particle_locations by first permuting
-        # the particles according to the sort order, then by selecting the
-        # credible particles.
-        if return_outside:
-            return (
-                mps[id_sort][id_cred], 
-                mps[id_sort][np.logical_not(id_cred)] 
-            )
-        else:
-            return mps[id_sort][id_cred]
-    
-    def region_est_hull(self, level=0.95, modelparam_slice=None):
-        """
-        Estimates a credible region over models by taking the convex hull of
-        a credible subset of particles.
-        
-        :param float level: The desired crediblity level (see
-            :meth:`SMCUpdater.est_credible_region`).
-        :param slice modelparam_slice: Slice over which model parameters
-            to consider.
-
-        :return: The tuple ``(faces, vertices)`` where ``faces`` describes all the 
-            vertices of all of the faces on the exterior of the convex hull, and 
-            ``vertices`` is a list of all vertices on the exterior of the 
-            convex hull.
-        :rtype: ``faces`` is a ``numpy.ndarray`` with shape 
-            ``(n_face, n_mps, n_mps)`` and indeces ``(idx_face, idx_vertex, idx_mps)`` 
-            where ``n_mps`` corresponds to the size of ``modelparam_slice``.
-            ``vertices`` is an  ``numpy.ndarray`` of shape ``(n_vertices, n_mps)``.
-        """
-        points = self.est_credible_region(
-            level=level, 
-            modelparam_slice=modelparam_slice
-        )
-        hull = ConvexHull(points)
-        
-        return points[hull.simplices], points[uniquify(hull.vertices.flatten())]
-
-    def region_est_ellipsoid(self, level=0.95, tol=0.0001, modelparam_slice=None):
-        r"""
-        Estimates a credible region over models by finding the minimum volume
-        enclosing ellipse (MVEE) of a credible subset of particles.
-        
-        :param float level: The desired crediblity level (see
-            :meth:`SMCUpdater.est_credible_region`).
-        :param float tol: The allowed error tolerance in the MVEE optimization
-            (see :meth:`~qinfer.utils.mvee`).
-        :param slice modelparam_slice: Slice over which model parameters
-            to consider.
-
-        :return: A tuple ``(A, c)`` where ``A`` is the covariance 
-            matrix of the ellipsoid and ``c`` is the center.
-            A point :math:`\vec{x}` is in the ellipsoid whenever 
-            :math:`(\vec{x}-\vec{c})^{T}A^{-1}(\vec{x}-\vec{c})\leq 1`.
-        :rtype: ``A`` is ``np.ndarray`` of shape ``(n_mps,n_mps)`` and 
-            ``centroid`` is ``np.ndarray`` of shape ``(n_mps)``. 
-            ``n_mps`` corresponds to the size of ``param_slice``.
-        """
-        _, vertices = self.region_est_hull(level=level, modelparam_slice=modelparam_slice)
-                
-        A, centroid = mvee(vertices, tol)
-        return A, centroid
-
-    def in_credible_region(self, points, level=0.95, modelparam_slice=None, method='hpd-hull', tol=0.0001):
-        """
-        Decides whether each of the points lie within a credible region 
-        of the current distribution.
-
-        If ``tol`` is ``None``, the particles are tested directly against 
-        the convex hull object. If ``tol`` is a positive ``float``, 
-        particles are tested to be in the interior of the smallest 
-        enclosing ellipsoid of this convex hull, see 
-        :meth:`SMCUpdater.region_est_ellipsoid`.
-
-        :param np.ndarray points: An ``np.ndarray`` of shape ``(n_mps)`` for 
-            a single point, or of shape ``(n_points, n_mps)`` for multiple points,
-            where ``n_mps`` corresponds to the same dimensionality as ``param_slice``.
-        :param float level: The desired crediblity level (see
-            :meth:`SMCUpdater.est_credible_region`).
-        :param str method: A string specifying which credible region estimator to 
-            use. One of ``'pce'``, ``'hpd-hull'`` or ``'hpd-mvee'`` (see below).
-        :param float tol: The allowed error tolerance for those methods 
-            which require a tolerance (see :meth:`~qinfer.utils.mvee`).
-        :param slice modelparam_slice: A slice describing which model parameters 
-            to consider in the credible region, effectively marginizing out the
-            remaining parameters. By default, all model parameters are included.
-
-        :return: A boolean array of shape ``(n_points, )`` specifying whether 
-            each of the points lies inside the confidence region.
-
-        Methods
-        ~~~~~~~
-
-        The following values are valid for the ``method`` argument.
-
-        - ``'pce'``: Posterior Covariance Ellipsoid.
-            Computes the covariance
-            matrix of the particle distribution marginalized over the excluded
-            slices and uses the :math:`\chi^2` distribution to determine
-            how to rescale it such the the corresponding ellipsoid has 
-            the correct size. The ellipsoid is translated by the 
-            mean of the particle distribution. It is determined which 
-            of the ``points`` are on the interior.
-        - ``'hpd-hull'``: High Posterior Density Convex Hull. 
-            See :meth:`SMCUpdater.region_est_hull`. Computes the 
-            HPD region resulting from the particle approximation, computes 
-            the convex hull of this, and it is determined which 
-            of the ``points`` are on the interior.  
-        - ``'hpd-mvee'``: High Posterior Density Minimum Volume Enclosing Ellipsoid. 
-            See :meth:`SMCUpdater.region_est_ellipsoid` 
-            and :meth:`~qinfer.utils.mvee`. Computes the 
-            HPD region resulting from the particle approximation, computes 
-            the convex hull of this, and determines the minimum enclosing 
-            ellipsoid. Deterimines which 
-            of the ``points`` are on the interior.  
-        """
-        
-        if method == 'pce':
-            s_ = np.s_[modelparam_slice] if modelparam_slice is not None else np.s_[:]
-            A = self.est_covariance_mtx()[s_, s_]
-            c = self.est_mean()[s_]
-            # chi-squared distribution gives correct level curve conversion
-            mult = scipy.stats.chi2.ppf(level, c.size)
-            results = in_ellipsoid(points, mult * A, c)
-
-        elif method == 'hpd-mvee':
-            tol = 0.0001 if tol is None else tol
-            A, c = self.region_est_ellipsoid(level=level, tol=tol, modelparam_slice=modelparam_slice)
-            results = in_ellipsoid(points, np.linalg.inv(A), c)
-
-        elif method == 'hpd-hull':
-            # it would be more natural to call region_est_hull,
-            # but that function uses ConvexHull which has no 
-            # easy way of determining if a point is interior.
-            # Here, Delaunay gives us access to all of the 
-            # necessary simplices.
-
-            # this fills the convex hull with (n_mps+1)-dimensional
-            # simplices; the convex hull is an almost-everywhere 
-            # disjoint union of these simplices
-            hull = Delaunay(self.est_credible_region(level=level, modelparam_slice=modelparam_slice))
-
-            # now we just check whether each of the given points are in 
-            # any of the simplices. (http://stackoverflow.com/a/16898636/1082565)
-            results = hull.find_simplex(points) >= 0
-
-        return results
-            
-        
     ## MISC METHODS ###########################################################
-    
+
     def risk(self, x0):
         return self.bayes_risk(np.array([(x0,)], dtype=self.model.expparams_dtype))
-        
+
     ## PLOTTING METHODS #######################################################
-    
+
     def posterior_marginal(self, idx_param=0, res=100, smoothing=0, range_min=None, range_max=None):
         """
-        Returns an estimate of the marginal distribution of a given model parameter, based on 
+        Returns an estimate of the marginal distribution of a given model parameter, based on
         taking the derivative of the interpolated cdf.
-        
+
         :param int idx_param: Index of parameter to be marginalized.
         :param int res1: Resolution of of the axis.
         :param float smoothing: Standard deviation of the Gaussian kernel
             used to smooth; same units as parameter.
         :param float range_min: Minimum range of the output axis.
         :param float range_max: Maximum range of the output axis.
-            
+
         .. seealso::
-        
+
             :meth:`SMCUpdater.plot_posterior_marginal`
         """
 
@@ -1064,7 +653,7 @@ class SMCUpdater(Distribution):
         # interp1d would  do it anyways (using argsort, too), so it's not a waste
         s = np.argsort(self.particle_locations[:,idx_param])
         locs = self.particle_locations[s,idx_param]
-        
+
         # relevant axis discretization
         r_min = np.min(locs) if range_min is None else range_min
         r_max = np.max(locs) if range_max is None else range_max
@@ -1072,7 +661,7 @@ class SMCUpdater(Distribution):
 
         # interpolate the cdf of the marginal distribution using cumsum
         interp = scipy.interpolate.interp1d(
-            np.append(locs, r_max + np.abs(r_max-r_min)), 
+            np.append(locs, r_max + np.abs(r_max-r_min)),
             np.append(np.cumsum(self.particle_weights[s]), 1),
             #kind='cubic',
             bounds_error=False,
@@ -1084,7 +673,7 @@ class SMCUpdater(Distribution):
         pr = np.gradient(interp(ps), ps[1]-ps[0])
         if smoothing > 0:
             gaussian_filter1d(pr, res*smoothing/(np.abs(r_max-r_min)), output=pr)
-            
+
         del interp
 
         return ps, pr
@@ -1095,7 +684,7 @@ class SMCUpdater(Distribution):
         ):
         """
         Plots a marginal of the requested parameter.
-        
+
         :param int idx_param: Index of parameter to be marginalized.
         :param int res1: Resolution of of the axis.
         :param float smoothing: Standard deviation of the Gaussian kernel
@@ -1108,9 +697,9 @@ class SMCUpdater(Distribution):
             matplotlib's ``plot`` function.
         :param np.ndarray true_model: Plots a given model parameter vector
             as the "true" model for comparison.
-            
+
         .. seealso::
-        
+
             :meth:`SMCUpdater.posterior_marginal`
         """
         res = plt.plot(*self.posterior_marginal(
@@ -1170,7 +759,7 @@ class SMCUpdater(Distribution):
         """
         Returns a mesh, useful for plotting, of kernel density estimation
         of a 2D projection of the current posterior distribution.
-        
+
         :param int idx_param1: Parameter to be treated as :math:`x` when
             plotting.
         :param int idx_param2: Parameter to be treated as :math:`y` when
@@ -1179,22 +768,22 @@ class SMCUpdater(Distribution):
         :param int res2: Resolution along the :math:`y` direction.
         :param float smoothing: Standard deviation of the Gaussian kernel
             used to smooth the particle approximation to the current posterior.
-            
+
         .. seealso::
-        
+
             :meth:`SMCUpdater.plot_posterior_contour`
         """
 
         # WARNING: fancy indexing is used here, which means that a copy is
         #          made.
         locs = self.particle_locations[:, [idx_param1, idx_param2]]
-    
+
         p1s, p2s = np.meshgrid(
             np.linspace(np.min(locs[:, 0]), np.max(locs[:, 0]), res1),
             np.linspace(np.min(locs[:, 1]), np.max(locs[:, 1]), res2)
         )
         plot_locs = np.array([p1s, p2s]).T.reshape((np.prod(p1s.shape), 2))
-        
+
         pr = np.sum( # <- sum over the particles in the SMC approximation.
             np.prod( # <- product over model parameters to get a multinormal
                 # Evaluate the PDF at the plotting locations, with a normal
@@ -1208,14 +797,14 @@ class SMCUpdater(Distribution):
             ) * self.particle_weights,
             axis=1
         ).reshape(p1s.shape) # Finally, reshape back into the same shape as the mesh.
-        
+
         return p1s, p2s, pr
-    
+
     def plot_posterior_contour(self, idx_param1=0, idx_param2=1, res1=100, res2=100, smoothing=0.01):
         """
         Plots a contour of the kernel density estimation
         of a 2D projection of the current posterior distribution.
-        
+
         :param int idx_param1: Parameter to be treated as :math:`x` when
             plotting.
         :param int idx_param2: Parameter to be treated as :math:`y` when
@@ -1224,15 +813,15 @@ class SMCUpdater(Distribution):
         :param int res2: Resolution along the :math:`y` direction.
         :param float smoothing: Standard deviation of the Gaussian kernel
             used to smooth the particle approximation to the current posterior.
-            
+
         .. seealso::
-        
+
             :meth:`SMCUpdater.posterior_mesh`
         """
         return plt.contour(*self.posterior_mesh(idx_param1, idx_param2, res1, res2, smoothing))
-        
+
     ## IPYTHON SUPPORT METHODS ################################################
-    
+
     def _repr_html_(self):
         return r"""
         <strong>{cls_name}</strong> for model of type <strong>{model}</strong>:
@@ -1261,11 +850,11 @@ class SMCUpdater(Distribution):
                     "</strong>, <strong>".join(type(model).__name__ for model in self.model.model_chain)
                 )
             ),
-            
+
             parameter_names="\n".join(
                 map("<td>${}$</td>".format, self.model.modelparam_names)
             ),
-            
+
             # TODO: change format string based on number of digits of precision
             #       admitted by the variance.
             parameter_values="\n".join(
@@ -1275,11 +864,11 @@ class SMCUpdater(Distribution):
                 for mu, std in
                 zip(self.est_mean(), np.sqrt(np.diag(self.est_covariance_mtx())))
             ),
-            
+
             resample_count=self.resample_count
         )
-        
-          
+
+
 class MixedApproximateSMCUpdater(SMCUpdater):
     """
     Subclass of :class:`SMCUpdater` that uses a mixture of two models, one
@@ -1298,34 +887,34 @@ class MixedApproximateSMCUpdater(SMCUpdater):
         of the value of ``mixture_ratio``.
     :param int min_good: Minimum number of "good" particles to assign at each
         step.
-        
+
     All other parameters are as described in the documentation of
     :class:`SMCUpdater`.
     """
-                
+
     def __init__(self,
             good_model, approximate_model,
             n_particles, prior,
             resample_a=None, resampler=None, resample_thresh=0.5,
             mixture_ratio=0.5, mixture_thresh=1.0, min_good=0
             ):
-            
+
         self._good_model = good_model
         self._apx_model = approximate_model
-        
+
         super(MixedApproximateSMCUpdater, self).__init__(
             good_model, n_particles, prior,
             resample_a, resampler, resample_thresh
         )
-        
+
         self._mixture_ratio = mixture_ratio
         self._mixture_thresh = mixture_thresh
         self._min_good = min_good
-                
+
     def hypothetical_update(self, outcomes, expparams, return_likelihood=False, return_normalization=False):
         # TODO: consolidate code with SMCUpdater by breaking update logic
         #       into private method.
-        
+
         # It's "hypothetical", don't want to overwrite old weights yet!
         weights = self.particle_weights
         locs = self.particle_locations
@@ -1340,7 +929,7 @@ class MixedApproximateSMCUpdater(SMCUpdater):
         L = np.zeros((outcomes.shape[0], locs.shape[0], expparams.shape[0]))
 
         # Which indices go to good_model?
-        
+
         # Start by getting a permutation that sorts the weights.
         # Since sorting as implemented by NumPy is stable, we want to break
         # that stability to avoid introducing patterns, and so we first
@@ -1348,11 +937,11 @@ class MixedApproximateSMCUpdater(SMCUpdater):
         idxs_random = np.arange(weights.shape[0])
         np.random.shuffle(idxs_random)
         idxs_sorted = np.argsort(weights[idxs_random])
-        
+
         # Find the inverse permutation to be that which returns
         # the composed permutation sort º shuffle to the identity.
         inv_idxs_sort = np.argsort(idxs_random[idxs_sorted])
-        
+
         # Now strip off a set of particles producing the desired total weight
         # or that have weights above a given threshold.
         sorted_weights = weights[idxs_random[idxs_sorted]]
@@ -1366,29 +955,29 @@ class MixedApproximateSMCUpdater(SMCUpdater):
             good_mask = np.zeros_like(good_mask)
             good_mask[idxs_random[idxs_sorted][-self._min_good:]] = True
         bad_mask = np.logical_not(good_mask)
-        
+
         # Finally, separate out the locations that go to each of the good and
         # bad models.
         locs_good = locs[good_mask, :]
         locs_bad = locs[bad_mask, :]
-        
+
         assert_thresh=1e-6
         assert np.mean(weights[good_mask]) - np.mean(weights[bad_mask]) >= -assert_thresh
-        
+
         # Now find L for each of the good and bad models.
         L[:, good_mask, :] = self._good_model.likelihood(outcomes, locs_good, expparams)
         L[:, bad_mask, :] = self._apx_model.likelihood(outcomes, locs_bad, expparams)
         L = L.transpose([0, 2, 1])
-        
+
         # update the weights sans normalization
         # Rearrange so that likelihoods have shape (outcomes, experiments, models).
         # This makes the multiplication with weights (shape (models,)) make sense,
         # since NumPy broadcasting rules align on the right-most index.
         hyp_weights = weights * L
-        
+
         # Sum up the weights to find the renormalization scale.
         norm_scale = np.sum(hyp_weights, axis=2)[..., np.newaxis]
-        
+
         # As a special case, check whether any entries of the norm_scale
         # are zero. If this happens, that implies that all of the weights are
         # zero--- that is, that the hypothicized outcome was impossible.
@@ -1401,7 +990,7 @@ class MixedApproximateSMCUpdater(SMCUpdater):
         # and so we save the "fixed" norm_scale to a new array.
         fixed_norm_scale = norm_scale.copy()
         fixed_norm_scale[np.abs(norm_scale) < np.spacing(1)] = 1
-        
+
         # normalize
         norm_weights = hyp_weights / fixed_norm_scale
             # Note that newaxis is needed to align the two matrices.
@@ -1417,18 +1006,18 @@ class MixedApproximateSMCUpdater(SMCUpdater):
                 return norm_weights, L
             else:
                 return norm_weights, L, norm_scale
-                
+
 class SMCUpdaterBCRB(SMCUpdater):
     """
 
     Subclass of :class:`SMCUpdater`, adding Bayesian Cramer-Rao bound
     functionality.
-    
+
     Models considered by this class must be differentiable.
-    
+
     In addition to the arguments taken by :class:`SMCUpdater`, this class
     takes the following keyword-only arguments:
-        
+
     :param bool adaptive: If `True`, the updater will track both the
         non-adaptive and adaptive Bayes Information matrices.
     :param initial_bim: If the regularity conditions are not met, then taking
@@ -1436,7 +1025,7 @@ class SMCUpdaterBCRB(SMCUpdater):
         initial BIM. In such cases, ``initial_bim`` can be set to the correct
         BIM corresponding to having done no experiments.
     """
-    
+
 
 
     def __init__(self, *args, **kwargs):
@@ -1447,10 +1036,10 @@ class SMCUpdaterBCRB(SMCUpdater):
                 'prior', 'n_particles'
             ]
         })
-        
+
         if not isinstance(self.model, DifferentiableModel):
             raise ValueError("Model must be differentiable.")
-        
+
         # TODO: fix distributions to make grad_log_pdf return the right
         #       shape, such that the indices are
         #       [idx_model, idx_param] → [idx_model, idx_param],
@@ -1466,7 +1055,7 @@ class SMCUpdaterBCRB(SMCUpdater):
             ) / self.n_particles
         else:
             self._current_bim = kwargs['initial_bim']
-            
+
         # Also track the adaptive BIM, if we've been asked to.
         if "adaptive" in kwargs and kwargs["adaptive"]:
             self._track_adaptive = True
@@ -1475,30 +1064,30 @@ class SMCUpdaterBCRB(SMCUpdater):
             self._adaptive_bim = self.current_bim
         else:
             self._track_adaptive = False
-    
+
     # TODO: since we are guaranteed differentiability, and since SMCUpdater is
     #       now a Distribution subclass representing posterior sampling, write
     #       a grad_log_pdf for the posterior distribution, perhaps?
-        
+
     def _bim(self, modelparams, expparams, modelweights=None):
         # TODO: document
         #       rough idea of this function is to take expectations of an
         #       FI over some distribution, here represented by modelparams.
-        
+
         # NOTE: The signature of this function is a bit odd, but it allows
         #       us to represent in one function both prior samples of uniform
         #       weight and weighted samples from a posterior.
         #       Because it's a bit odd, we make it a private method and expose
         #       functionality via the prior_bayes_information and
         #       posterior_bayes_information methods.
-        
+
         # About shapes: the FI we will be averaging over has four indices:
         # FI[i, j, m, e], i and j being matrix indices, m being a model index
         # and e being a model index.
         # We will thus want to return an array of shape BI[i, j, e], reducing
         # over the model index.
         fi = self.model.fisher_information(modelparams, expparams)
-        
+
         # We now either reweight and sum, or sum and divide, based on whether we
         # have model weights to consider or not.
         if modelweights is None:
@@ -1506,9 +1095,9 @@ class SMCUpdaterBCRB(SMCUpdater):
             bim = np.sum(fi, axis=2) / modelparams.shape[0]
         else:
             bim = np.einsum("m,ijme->ije", modelweights, fi)
-            
+
         return bim
-    
+
 
     @property
     def current_bim(self):
@@ -1524,8 +1113,8 @@ class SMCUpdaterBCRB(SMCUpdater):
     def adaptive_bim(self):
         """
         Returns a copy of the adaptive Bayesian Information Matrix (BIM)
-        of the :class:`SMCUpdaterBCRB`. Will raise an error if 
-        `method`:`SMCUpdaterBCRB.track_adaptive` is `False`. 
+        of the :class:`SMCUpdaterBCRB`. Will raise an error if
+        `method`:`SMCUpdaterBCRB.track_adaptive` is `False`.
 
         :returns: `np.array` of shape [idx_modelparams,idx_modelparams]
         """
@@ -1533,24 +1122,24 @@ class SMCUpdaterBCRB(SMCUpdater):
             raise ValueError('To track the adaptive_bim, the adaptive keyword argument'
                 'must be set True when initializing class.')
         return np.copy(self._adaptive_bim)
-    
+
     @property
     def track_adaptive(self):
         """
-        If `True` the :class:`SMCUpdaterBCRB` will track the adaptive BIM. Set by 
+        If `True` the :class:`SMCUpdaterBCRB` will track the adaptive BIM. Set by
         keyword argument `adaptive` to :method:`SMCUpdaterBCRB.__init__`.
 
         :returns: `bool`
         """
         return self._track_adaptive
-    
-    
-    
-    
+
+
+
+
     def prior_bayes_information(self, expparams, n_samples=None):
         """
-        Evaluates the local Bayesian Information Matrix (BIM) for a set of 
-        samples from the SMC particle set, with uniform weights. 
+        Evaluates the local Bayesian Information Matrix (BIM) for a set of
+        samples from the SMC particle set, with uniform weights.
 
         :param expparams: Parameters describing the experiment that was
             performed.
@@ -1559,17 +1148,17 @@ class SMCUpdaterBCRB(SMCUpdater):
             of the underlying model
 
         :param n_samples int: Number of samples to draw from particle distribution,
-                        to evaluate BIM over. 
+                        to evaluate BIM over.
         """
 
         if n_samples is None:
             n_samples = self.particle_locations.shape[0]
         return self._bim(self.prior.sample(n_samples), expparams)
-        
+
     def posterior_bayes_information(self, expparams):
         """
         Evaluates the local Bayesian Information Matrix (BIM) over all particles
-        of the current posterior distribution with corresponding weights. 
+        of the current posterior distribution with corresponding weights.
 
         :param expparams: Parameters describing the experiment that was
             performed.
@@ -1582,7 +1171,7 @@ class SMCUpdaterBCRB(SMCUpdater):
             self.particle_locations, expparams,
             modelweights=self.particle_weights
         )
-        
+
     def update(self, outcome, expparams,check_for_resample=True):
         """
         Given an experiment and an outcome of that experiment, updates the
@@ -1604,13 +1193,13 @@ class SMCUpdaterBCRB(SMCUpdater):
         # Before we update, we need to commit the new Bayesian information
         # matrix corresponding to the measurement we just made.
         self._current_bim += self.prior_bayes_information(expparams)[:, :, 0]
-        
+
         # If we're tracking the information content accessible to adaptive
         # algorithms, then we must use the current posterior as the prior
         # for the next step, then add that accordingly.
         if self._track_adaptive:
             self._adaptive_bim += self.posterior_bayes_information(expparams)[:, :, 0]
-        
+
         # We now can update as normal.
         SMCUpdater.update(self, outcome, expparams,check_for_resample=check_for_resample)
-        
+

--- a/src/qinfer/utils.py
+++ b/src/qinfer/utils.py
@@ -5,7 +5,7 @@
 ##
 # © 2012 Chris Ferrie (csferrie@gmail.com) and
 #        Christopher E. Granade (cgranade@gmail.com)
-#     
+#
 # This file is a part of the Qinfer project.
 # Licensed under the AGPL version 3.
 ##
@@ -53,12 +53,12 @@ from qinfer._exceptions import ApproximationWarning
 
 def get_qutip_module(required_version='3.2'):
     """
-    Attempts to return the qutip module, but 
-    silently returns ``None`` if it can't be 
-    imported, or doesn't have version at 
+    Attempts to return the qutip module, but
+    silently returns ``None`` if it can't be
+    imported, or doesn't have version at
     least ``required_version``.
 
-    :param str required_version: Valid input to 
+    :param str required_version: Valid input to
         ``distutils.version.LooseVersion``.
     :return: The qutip module or ``None``.
     :rtype: ``module`` or ``NoneType``
@@ -76,11 +76,11 @@ def get_qutip_module(required_version='3.2'):
 
 def check_qutip_version(required_version='3.2'):
     """
-    Returns ``true`` iff the imported qutip 
-    version exists and has ``LooseVersion`` 
+    Returns ``true`` iff the imported qutip
+    version exists and has ``LooseVersion``
     of at least ``required_version``.
 
-    :param str required_version: Valid input to 
+    :param str required_version: Valid input to
         ``distutils.version.LooseVersion``.
     :rtype: ``bool``
     """
@@ -88,7 +88,7 @@ def check_qutip_version(required_version='3.2'):
         qt = get_qutip_module(required_version)
         return qt is not None
     except:
-        # In any other case (including something other 
+        # In any other case (including something other
         # than ImportError) we say it's not good enough
         return False
 
@@ -106,19 +106,19 @@ def multinomial_pdf(n,p):
     :math:`\operatorname{Multinomial}(N, n, p)=
         \frac{N!}{n_1!\cdots n_k!}p_1^{n_1}\cdots p_k^{n_k}`
 
-    :param np.ndarray n : Array of outcome integers 
-        of shape ``(sides, ...)`` where sides is the number of 
-        sides on the dice and summing over this index indicates 
+    :param np.ndarray n : Array of outcome integers
+        of shape ``(sides, ...)`` where sides is the number of
+        sides on the dice and summing over this index indicates
         the number of rolls for the given experiment.
-    :param np.ndarray p : Array of (assumed) probabilities 
-        of shape ``(sides, ...)`` or ``(sides-1,...)`` 
+    :param np.ndarray p : Array of (assumed) probabilities
+        of shape ``(sides, ...)`` or ``(sides-1,...)``
         with the rest of the dimensions the same as ``n``.
-        If ``sides-1``, the last probability is chosen so that the 
-        probabilities of all sides sums to 1. If ``sides`` 
-        is the last index, these probabilities are assumed 
+        If ``sides-1``, the last probability is chosen so that the
+        probabilities of all sides sums to 1. If ``sides``
+        is the last index, these probabilities are assumed
         to sum to 1.
 
-    Note that the numbers of experiments don't need to be given because 
+    Note that the numbers of experiments don't need to be given because
     they are implicit in the sum over the 0 index of ``n``.
     """
 
@@ -126,7 +126,7 @@ def multinomial_pdf(n,p):
     log_N_fac = gammaln(np.sum(n, axis=0) + 1)[np.newaxis,...]
     log_n_fac_sum = np.sum(gammaln(n + 1), axis=0)
 
-    # since working in log space, we need special 
+    # since working in log space, we need special
     # consideration at p=0. deal with p=0, n>0 later.
     def nlogp(n,p):
         result = np.zeros(p.shape)
@@ -136,7 +136,7 @@ def multinomial_pdf(n,p):
 
     if p.shape[0] == n.shape[0] - 1:
         ep = np.empty(n.shape)
-        ep[:p.shape[0],...] = p 
+        ep[:p.shape[0],...] = p
         ep[-1,...] = 1-np.sum(p,axis=0)
     else:
         ep = p
@@ -144,7 +144,7 @@ def multinomial_pdf(n,p):
 
     probs = np.exp(log_N_fac - log_n_fac_sum + log_p_sum)
 
-    # if n_k>0 but p_k=0, the whole probability must be 0 
+    # if n_k>0 but p_k=0, the whole probability must be 0
     mask = np.sum(np.logical_and(n!=0, ep==0), axis=0) == 0
     probs = mask * probs
 
@@ -152,21 +152,21 @@ def multinomial_pdf(n,p):
 
 def sample_multinomial(N, p, size=None):
     r"""
-    Draws fixed number of samples N from different 
+    Draws fixed number of samples N from different
     multinomial distributions (with the same number dice sides).
 
     :param int N: How many samples to draw from each distribution.
     :param np.ndarray p: Probabilities specifying each distribution.
         Sum along axis 0 should be 1.
-    :param size: Output shape. ``int`` or tuple of 
-        ``int``s. If the given shape is, 
-        e.g., ``(m, n, k)``, then m * n * k samples are drawn 
-        for each distribution. 
-        Default is None, in which case a single value 
+    :param size: Output shape. ``int`` or tuple of
+        ``int``s. If the given shape is,
+        e.g., ``(m, n, k)``, then m * n * k samples are drawn
+        for each distribution.
+        Default is None, in which case a single value
         is returned for each distribution.
 
     :rtype: np.ndarray
-    :return: Array of shape ``(p.shape, size)`` or p.shape if 
+    :return: Array of shape ``(p.shape, size)`` or p.shape if
         size is ``None``.
     """
     # ensure s is array
@@ -177,7 +177,7 @@ def sample_multinomial(N, p, size=None):
         return np.random.multinomial(N, ps, np.prod(s)).flatten()
 
     # should have shape (prod(size)*ps.shape[0], ps.shape[1:])
-    samples = np.apply_along_axis(take_samples, 0, p) 
+    samples = np.apply_along_axis(take_samples, 0, p)
     # should have shape (size, p.shape)
     samples = samples.reshape(np.concatenate([s, p.shape]))
     # should have shape (p.shape, size)
@@ -196,13 +196,13 @@ def outer_product(vec):
     r"""
     Returns the outer product of a vector :math:`v`
     with itself, :math:`v v^\T`.
-    """        
+    """
     return (
         np.dot(vec[:, np.newaxis], vec[np.newaxis, :])
         if len(vec.shape) == 1 else
         np.dot(vec, vec.T)
         )
-        
+
 def particle_meanfn(weights, locations, fn=None):
     r"""
     Returns the mean of a function :math:`f` over model
@@ -215,18 +215,18 @@ def particle_meanfn(weights, locations, fn=None):
         take the mean of. If `None`, the identity function
         is assumed.
     """
-    warnings.warn('particle_meanfn is depreceated, please use distributions.ParticleDistribution',
+    warnings.warn('particle_meanfn is deprecated, please use distributions.ParticleDistribution',
                   DeprecationWarning)
     fn_vals = fn(locations) if fn is not None else locations
     return np.sum(weights * fn_vals.transpose([1, 0]),
         axis=1)
 
-    
+
 def particle_covariance_mtx(weights,locations):
     """
     Returns an estimate of the covariance of a distribution
     represented by a given set of SMC particle.
-        
+
     :param weights: An array containing the weights of each
         particle.
     :param location: An array containing the locations of
@@ -236,12 +236,12 @@ def particle_covariance_mtx(weights,locations):
     :returns: An array containing the estimated covariance matrix.
     """
     # TODO: add shapes to docstring.
-    warnings.warn('particle_covariance_mtx is depreceated, please use distributions.ParticleDistribution',
+    warnings.warn('particle_covariance_mtx is deprecated, please use distributions.ParticleDistribution',
                   DeprecationWarning)
-        
+
     # Find the mean model vector, shape (n_modelparams, ).
     mu = particle_meanfn(weights, locations)
-    
+
     # Transpose the particle locations to have shape
     # (n_modelparams, n_particles).
     xs = locations.transpose([1, 0])
@@ -266,7 +266,7 @@ def particle_covariance_mtx(weights,locations):
         # the outer product $mu . mu^T$.
         - np.dot(mu[..., np.newaxis], mu[np.newaxis, ...])
     )
-    
+
     # The SMC approximation is not guaranteed to produce a
     # positive-semidefinite covariance matrix. If a negative eigenvalue
     # is produced, we should warn the caller of this.
@@ -274,7 +274,7 @@ def particle_covariance_mtx(weights,locations):
     if not np.all(la.eig(cov)[0] >= 0):
         warnings.warn('Numerical error in covariance estimation causing positive semidefinite violation.', ApproximationWarning)
 
-    return cov            
+    return cov
 
 
 def ellipsoid_volume(A=None, invA=None):
@@ -282,18 +282,18 @@ def ellipsoid_volume(A=None, invA=None):
     Returns the volume of an ellipsoid given either its
     matrix or the inverse of its matrix.
     """
-    
+
     if invA is None and A is None:
         raise ValueError("Must pass either inverse(A) or A.")
-        
+
     if invA is None and A is not None:
         invA = la.inv(A)
-    
+
     # Find the unit sphere volume.
     # http://en.wikipedia.org/wiki/Unit_sphere#General_area_and_volume_formulas
     n  = invA.shape[0]
     Vn = (np.pi ** (n/2)) / gamma(1 + (n/2))
-    
+
     return Vn * la.det(sqrtm(invA))
 
 @due.dcite(
@@ -307,18 +307,18 @@ def mvee(points, tol=0.001):
     of a set of points, using the Khachiyan algorithm.
     """
 
-    # This function is a port of the matlab function by 
+    # This function is a port of the matlab function by
     # Nima Moshtagh found here:
     # https://www.mathworks.com/matlabcentral/fileexchange/9542-minimum-volume-enclosing-ellipsoid
     # with accompanying writup here:
     # https://www.researchgate.net/profile/Nima_Moshtagh/publication/254980367_MINIMUM_VOLUME_ENCLOSING_ELLIPSOIDS/links/54aab5260cf25c4c472f487a.pdf
 
     N, d = points.shape
-    
+
     Q = np.zeros([N,d+1])
-    Q[:,0:d] = points[0:N,0:d]  
+    Q[:,0:d] = points[0:N,0:d]
     Q[:,d] = np.ones([1,N])
-    
+
     Q = np.transpose(Q)
     points = np.transpose(points)
     count = 1
@@ -326,31 +326,31 @@ def mvee(points, tol=0.001):
     u = (1/N) * np.ones(shape = (N,))
 
     while err > tol:
-        
+
         X = np.dot(np.dot(Q, np.diag(u)), np.transpose(Q))
-        M = np.diag( np.dot(np.dot(np.transpose(Q), la.inv(X)),Q)) 
+        M = np.diag( np.dot(np.dot(np.transpose(Q), la.inv(X)),Q))
         jdx = np.argmax(M)
         step_size = (M[jdx] - d - 1)/((d+1)*(M[jdx] - 1))
-        new_u = (1 - step_size)*u 
+        new_u = (1 - step_size)*u
         new_u[jdx] = new_u[jdx] + step_size
         count = count + 1
-        err = la.norm(new_u - u)       
+        err = la.norm(new_u - u)
         u = new_u
-    
-    U = np.diag(u)    
+
+    U = np.diag(u)
     c = np.dot(points,u)
-    A = (1/d) * la.inv(np.dot(np.dot(points,U), np.transpose(points)) - np.outer(c,c) )    
+    A = (1/d) * la.inv(np.dot(np.dot(points,U), np.transpose(points)) - np.outer(c,c) )
     return A, np.transpose(c)
 
 def in_ellipsoid(x, A, c):
     """
-    Determines which of the points ``x`` are in the 
+    Determines which of the points ``x`` are in the
     closed ellipsoid with shape matrix ``A`` centered at ``c``.
-    For a single point ``x``, this is computed as 
+    For a single point ``x``, this is computed as
 
         .. math::
-            (c-x)^T\cdot A^{-1}\cdot (c-x) \leq 1 
-        
+            (c-x)^T\cdot A^{-1}\cdot (c-x) \leq 1
+
     :param np.ndarray x: Shape ``(n_points, dim)`` or ``n_points``.
     :param np.ndarray A: Shape ``(dim, dim)``, positive definite
     :param np.ndarray c: Shape ``(dim)``
@@ -374,14 +374,14 @@ def uniquify(seq):
 
 def assert_sigfigs_equal(x, y, sigfigs=3):
     """
-    Tests if all elements in x and y 
-    agree up to a certain number of 
+    Tests if all elements in x and y
+    agree up to a certain number of
     significant figures.
 
     :param np.ndarray x: Array of numbers.
     :param np.ndarray y: Array of numbers you want to
         be equal to ``x``.
-    :param int sigfigs: How many significant 
+    :param int sigfigs: How many significant
         figures you demand that they share.
         Default is 3.
     """
@@ -414,7 +414,7 @@ def format_uncertainty(value, uncertianty, scinotn_break=4):
         # Zero should be printed as a single digit; that is, as wide as str "1".
         mag_val = int(np.log10(np.abs(value))) if value != 0 else 0
         n_digits = max(mag_val - mag_unc, 0)
-            
+
 
         if abs(mag_val) < abs(mag_unc) and abs(mag_unc) > scinotn_break:
             # We're formatting something close to zero, so recale uncertianty
@@ -438,7 +438,7 @@ def format_uncertainty(value, uncertianty, scinotn_break=4):
                 uncertianty / scale,
                 mag_val
            )
-           
+
 def compactspace(scale, n):
     r"""
     Returns points :math:`x` spaced in the open interval
@@ -449,7 +449,7 @@ def compactspace(scale, n):
     logit = logistic(scale=scale).ppf
     compact_xs = np.linspace(0, 1, n + 2)[1:-1]
     return logit(compact_xs)
-           
+
 
 def pretty_time(secs, force_h=False, force_m=False):
     if secs > 86400:
@@ -466,13 +466,13 @@ def pretty_time(secs, force_h=False, force_m=False):
 def safe_shape(arr, idx=0, default=1):
     shape = np.shape(arr)
     return shape[idx] if idx < len(shape) else default
-    
+
 def join_struct_arrays(arrays):
     """
     Takes a list of possibly structured arrays, concatenates their
-    dtypes, and returns one big array with that dtype. Does the 
+    dtypes, and returns one big array with that dtype. Does the
     inverse of ``separate_struct_array``.
-    
+
     :param list arrays: List of ``np.ndarray``s
     """
     # taken from http://stackoverflow.com/questions/5355744/numpy-joining-structured-arrays
@@ -484,13 +484,13 @@ def join_struct_arrays(arrays):
         joint[...,offset:offset+size] = np.atleast_1d(a).view(np.uint8).reshape(shape + (size,))
     dtype = sum((a.dtype.descr for a in arrays), [])
     return joint.ravel().view(dtype)
-    
+
 def separate_struct_array(array, dtypes):
     """
-    Takes an array with a structured dtype, and separates it out into 
+    Takes an array with a structured dtype, and separates it out into
     a list of arrays with dtypes coming from the input ``dtypes``.
     Does the inverse of ``join_struct_arrays``.
-    
+
     :param np.ndarray array: Structured array.
     :param dtypes: List of ``np.dtype``, or just a ``np.dtype`` and the number of
         them is figured out automatically by counting bytes.
@@ -524,7 +524,7 @@ def sqrtm_psd(A, est_error=True, check_finite=True):
         return A_sqrt, np.linalg.norm(np.dot(A_sqrt, A_sqrt) - A, 'fro')
     else:
         return A_sqrt
-    
+
 #==============================================================================
 #Test Code
 if __name__ == "__main__":
@@ -533,48 +533,48 @@ if __name__ == "__main__":
     from mpl_toolkits.mplot3d.art3d import Poly3DCollection
     import matplotlib.pyplot as plt
     from scipy.spatial import Delaunay
-    
+
     #some random points
-    points = np.array([[ 0.53135758, -0.25818091, -0.32382715], 
-    [ 0.58368177, -0.3286576,  -0.23854156,], 
-    [ 0.18741533,  0.03066228, -0.94294771], 
+    points = np.array([[ 0.53135758, -0.25818091, -0.32382715],
+    [ 0.58368177, -0.3286576,  -0.23854156,],
+    [ 0.18741533,  0.03066228, -0.94294771],
     [ 0.65685862, -0.09220681, -0.60347573],
     [ 0.63137604, -0.22978685, -0.27479238],
     [ 0.59683195, -0.15111101, -0.40536606],
     [ 0.68646128,  0.0046802,  -0.68407367],
     [ 0.62311759,  0.0101013,  -0.75863324]])
-    
+
     # compute mvee
     A, centroid = mvee(points)
     print(A)
-    
+
     # point it and some other stuff
-    U, D, V = la.svd(A)    
-        
+    U, D, V = la.svd(A)
+
     rx, ry, rz = [1/np.sqrt(d) for d in D]
-    u, v = np.mgrid[0:2*np.pi:20j,-np.pi/2:np.pi/2:10j]    
-    
+    u, v = np.mgrid[0:2*np.pi:20j,-np.pi/2:np.pi/2:10j]
+
     x=rx*np.cos(u)*np.cos(v)
     y=ry*np.sin(u)*np.cos(v)
     z=rz*np.sin(v)
-            
+
     for idx in range(x.shape[0]):
         for idy in range(y.shape[1]):
             x[idx,idy],y[idx,idy],z[idx,idy] = np.dot(np.transpose(V),np.array([x[idx,idy],y[idx,idy],z[idx,idy]])) + centroid
-            
-    
+
+
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
-    ax.scatter(points[:,0],points[:,1],points[:,2])    
+    ax.scatter(points[:,0],points[:,1],points[:,2])
     ax.plot_surface(x, y, z, cstride = 1, rstride = 1, alpha = 0.1)
     plt.show()
- 
+
 def binom_est_p(n, N, hedge=float(0)):
     r"""
     Given a number of successes :math:`n` and a number of trials :math:`N`,
     estimates the binomial distribution parameter :math:`p` using the
     hedged maximum likelihood estimator of [FB12]_.
-    
+
     :param n: Number of successes.
     :type n: `numpy.ndarray` or `int`
     :param int N: Number of trials.
@@ -584,10 +584,10 @@ def binom_est_p(n, N, hedge=float(0)):
         value of :math:`n`.
     """
     return (n + hedge) / (N + 2 * hedge)
-    
+
 def binom_est_error(p, N, hedge = float(0)):
     r"""
     """
-    
+
     # asymptotic np.sqrt(p * (1 - p) / N)
     return np.sqrt(p*(1-p)/(N+2*hedge+1))

--- a/src/qinfer/utils.py
+++ b/src/qinfer/utils.py
@@ -215,6 +215,8 @@ def particle_meanfn(weights, locations, fn=None):
         take the mean of. If `None`, the identity function
         is assumed.
     """
+    warnings.warn('particle_meanfn is depreceated, please use distributions.ParticleDistribution',
+                  DeprecationWarning)
     fn_vals = fn(locations) if fn is not None else locations
     return np.sum(weights * fn_vals.transpose([1, 0]),
         axis=1)
@@ -233,7 +235,9 @@ def particle_covariance_mtx(weights,locations):
         ``(n_modelparams, n_modelparams)``.
     :returns: An array containing the estimated covariance matrix.
     """
-    # TODO: add shapes to docstring.        
+    # TODO: add shapes to docstring.
+    warnings.warn('particle_covariance_mtx is depreceated, please use distributions.ParticleDistribution',
+                  DeprecationWarning)
         
     # Find the mean model vector, shape (n_modelparams, ).
     mu = particle_meanfn(weights, locations)


### PR DESCRIPTION
This is a first suggestion how to move all the particle mean/covariance related logic into the `ParticleDistribution` class itself. This allows the user to provide his/her own moment-computing functions as show in [this Notebook](https://github.com/dseuss/qinfer-examples/blob/master/circular_statistics.ipynb).

I have not touched the clustering-resampler related stuff so far since this is work in progress. Once we have agreed on the right interface, this can certainly be done.

The other place that should be fixed is how the LW resampler combines the two resampling strategies [here](https://github.com/QInfer/python-qinfer/blob/master/src/qinfer/resamplers.py#L326). For each particle, this is a mean over two (virtual) particles with weights `a` and `1-a`. In the Notebook I get around the problem by disabling postselection and by running cannonicalization afterwards. 

BTW, Sorry for the unnecessary deleted whitespaces...