### PR TITLE
Possible bug in Resampler

### DIFF
--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -369,7 +369,7 @@ class LiuWestResampler(Resampler):
             # This may look a little weird, but it should delete the unused
             # elements of js, so that we don't need to reallocate.
             js = js[np.logical_not(valid_mask)]
-            mus = mus[:idxs_to_resample.size, :]
+            mus = mus[idxs_to_resample, :]
 
         if idxs_to_resample.size:
             # We failed to force all models to be valid within maxiter attempts.

--- a/src/qinfer/resamplers.py
+++ b/src/qinfer/resamplers.py
@@ -329,7 +329,8 @@ class LiuWestResampler(Resampler):
             n_iters += 1
 
             # Draw x_i from N(mu_i, S).
-            new_locs[idxs_to_resample, :] = mus + np.dot(S, self._kernel(n_rvs, mus.shape[0])).T
+            mus_temp = mus[idxs_to_resample, :]
+            new_locs[idxs_to_resample, :] = mus_temp + np.dot(S, self._kernel(n_rvs, mus_temp.shape[0])).T
 
             # Now we remove from the list any valid models.
             # We write it out in a longer form than is strictly necessary so
@@ -369,7 +370,7 @@ class LiuWestResampler(Resampler):
             # This may look a little weird, but it should delete the unused
             # elements of js, so that we don't need to reallocate.
             js = js[np.logical_not(valid_mask)]
-            mus = mus[idxs_to_resample, :]
+
 
         if idxs_to_resample.size:
             # We failed to force all models to be valid within maxiter attempts.


### PR DESCRIPTION
Considering the mus are not ordered, should one not use the mask to specify the remaining kernel locations around which there is still sampling to be done? In the simplest case, assume that only the last particle location in mu yields an invalid particle location when drawing, then in the current situation the algorithm would resample from a gaussian centered around the first location mu[0], not the last.

Edit: tried to add a fix